### PR TITLE
Height map rendering

### DIFF
--- a/src/main/java/engine/core/settings/EngineSettings.java
+++ b/src/main/java/engine/core/settings/EngineSettings.java
@@ -92,7 +92,7 @@ public class EngineSettings {
 	public final static float TESSELLATION_SHIFT = 0.1f;
 	
 	public final static float SCALE_XZ = 6000f;
-	public final static float SCALE_Y = 1f;
+	public final static float SCALE_Y = 10f;
 	
 	public final static int[] LOD_RANGES = {1750, 874, 386, 192, 100, 50, 0, 0};
 //	public final static int[] LOD_RANGES = {874, 386, 192, 100, 50, 0, 0, 0};

--- a/src/main/java/engine/core/settings/EngineSettings.java
+++ b/src/main/java/engine/core/settings/EngineSettings.java
@@ -92,10 +92,10 @@ public class EngineSettings {
 	public final static float TESSELLATION_SHIFT = 0.1f;
 	
 	public final static float SCALE_XZ = 6000f;
-	public final static float SCALE_Y = 10f;
+	public final static float SCALE_Y = 1f;
 	
-	public final static int[] LOD_RANGES = {1750, 874, 386, 192, 100, 50, 0, 0};
-//	public final static int[] LOD_RANGES = {874, 386, 192, 100, 50, 0, 0, 0};
+//	public final static int[] LOD_RANGES = {1750, 874, 386, 192, 100, 50, 0, 0};
+	public final static int[] LOD_RANGES = {4096, 2048, 1024, 512, 256, 64, 16, 0};
 //	public final static int[] LOD_RANGES = {500, 450, 350, 250, 150, 100, 50, 0};
 	public static int[] lod_morph_areas;
 

--- a/src/main/java/engine/core/settings/EngineSettings.java
+++ b/src/main/java/engine/core/settings/EngineSettings.java
@@ -14,8 +14,8 @@ import org.lwjgl.util.vector.Vector4f;
 public class EngineSettings {
 
 	/* display settings */
-	public static final int DISPLAY_WIDTH = 1920; // 1920;
-	public static final int DISPLAY_HEIGHT = 1080; // 1080;
+	public static final int DISPLAY_WIDTH = 800; // 1920;
+	public static final int DISPLAY_HEIGHT = 600; // 1080;
 	public static final int FAR_PLANE = 100000;
 	public static final float NEAR_PLANE = 0.5f;
 	public static final int FPS_CAP = 90;
@@ -92,9 +92,9 @@ public class EngineSettings {
 	public final static float TESSELLATION_SHIFT = 0.1f;
 	
 	public final static float SCALE_XZ = 6000f;
-	public final static float SCALE_Y = 200f;
+	public final static float SCALE_Y = 1f;
 	
-	public final static int[] LOD_RANGES = {1750, 874, 386, 192, 100, 50, 25, 0};
+	public final static int[] LOD_RANGES = {1750, 874, 386, 192, 100, 50, 0, 0};
 //	public final static int[] LOD_RANGES = {500, 450, 350, 250, 150, 100, 50, 0};
 	public static int[] lod_morph_areas;
 

--- a/src/main/java/engine/core/settings/EngineSettings.java
+++ b/src/main/java/engine/core/settings/EngineSettings.java
@@ -14,8 +14,8 @@ import org.lwjgl.util.vector.Vector4f;
 public class EngineSettings {
 
 	/* display settings */
-	public static final int DISPLAY_WIDTH = 1920; // 1920;
-	public static final int DISPLAY_HEIGHT = 1080; // 1080;
+	public static final int DISPLAY_WIDTH = 800; // 1920;
+	public static final int DISPLAY_HEIGHT = 600; // 1080;
 	public static final int FAR_PLANE = 100000;
 	public static final float NEAR_PLANE = 0.5f;
 	public static final int FPS_CAP = 90;
@@ -94,7 +94,8 @@ public class EngineSettings {
 	public final static float SCALE_XZ = 6000f;
 	public final static float SCALE_Y = 200f;
 	
-	public final static int[] LOD_RANGES = {1750, 874, 386, 192, 100, 50, 25, 0};
+	public final static int[] LOD_RANGES = {1750, 874, 386, 192, 100, 50, 0, 0};
+//	public final static int[] LOD_RANGES = {874, 386, 192, 100, 50, 0, 0, 0};
 //	public final static int[] LOD_RANGES = {500, 450, 350, 250, 150, 100, 50, 0};
 	public static int[] lod_morph_areas;
 

--- a/src/main/java/engine/manager/scene/SceneManager.java
+++ b/src/main/java/engine/manager/scene/SceneManager.java
@@ -138,7 +138,7 @@ public class SceneManager implements ISceneManager {
 			.forEach(entity -> scene.getFrustumEntities().addEntityInNodes(entity));
 		scene.setCamera(new TargetCamera(cameraName, player1));
 		scene.setSun(new Light("Sun", 
-				new Vector3f(-1000000, 2000000, -1000000), 
+				new Vector3f(-1000000, 5000000, -1000000), 
 				new Vector3f(1.3f, 1.3f, 1.3f)));
 		scene.getLights().add(scene.getSun());
 		scene.getLights().add(new Light("Light1", new Vector3f(200, 2, 200), new Vector3f(10, 0, 0),

--- a/src/main/java/engine/manager/scene/SceneManager.java
+++ b/src/main/java/engine/manager/scene/SceneManager.java
@@ -114,7 +114,7 @@ public class SceneManager implements ISceneManager {
 				scene.getAudioSources().getMaster());
 		ambientSource.setLooping(true);
 		ambientSource.setVolume(0.3f);
-		ambientSource.play();
+		// ambientSource.play();
 		ambientSource.setPosition(new Vector3f(400, 50, 400));
 
 		/*--------------WATER----------------*/

--- a/src/main/java/engine/object/terrain/terrain/ITerrain.java
+++ b/src/main/java/engine/object/terrain/terrain/ITerrain.java
@@ -5,7 +5,6 @@ import object.camera.ICamera;
 import object.terrain.generator.HeightsGenerator;
 import object.texture.Texture2D;
 import object.texture.terrain.TerrainTexturePack;
-import primitive.buffer.PatchVAO;
 import primitive.model.Mesh;
 
 /**
@@ -99,6 +98,14 @@ public interface ITerrain extends Nameable {
 	 * @return {@link String} value of height texture map name
 	 */
 	String getHeightMapName();
+	
+	Texture2D getHeightMap();
+	
+	void setHeightMap(Texture2D heightMap);
+	
+	Texture2D getNormalMap();
+	
+	void setNormalMap(Texture2D normalMap);
 
 	/**
 	 * Returns if terrain is procedurally generated or not.

--- a/src/main/java/engine/object/terrain/terrain/ITerrain.java
+++ b/src/main/java/engine/object/terrain/terrain/ITerrain.java
@@ -17,7 +17,7 @@ import primitive.model.Mesh;
  */
 public interface ITerrain extends Nameable {
 	
-	public static final int TERRAIN_VERTEX_COUNT = 256;
+	public static final int TERRAIN_VERTEX_COUNT = 512;
 	public static final int TERRAIN_SIZE = 10000;
 	
 	public static final float TERRAIN_SCALE_XZ = 1f;

--- a/src/main/java/engine/object/terrain/terrain/ITerrain.java
+++ b/src/main/java/engine/object/terrain/terrain/ITerrain.java
@@ -99,6 +99,10 @@ public interface ITerrain extends Nameable {
 	 * @return {@link String} value of height texture map name
 	 */
 	String getHeightMapName();
+	
+	Texture2D getHeightMap();
+	
+	void setHeightMap(Texture2D heightMap);
 
 	/**
 	 * Returns if terrain is procedurally generated or not.

--- a/src/main/java/engine/object/terrain/terrain/MappedTerrain.java
+++ b/src/main/java/engine/object/terrain/terrain/MappedTerrain.java
@@ -34,6 +34,7 @@ public class MappedTerrain extends ATerrain implements ITerrain {
 	private Mesh model;
 	private TerrainTexturePack texturePack;
 	private Texture2D blendMap;
+	private Texture2D heightMap;
 	private String heightMapName;
 	private boolean isProcedureGenerated = false;
 	private boolean isVisible = true;
@@ -258,6 +259,16 @@ public class MappedTerrain extends ATerrain implements ITerrain {
 		height /= MAX_PIXEL_COLOUR / 2f;
 		height *= MAX_HEIGHT;
 		return height;
+	}
+
+	@Override
+	public Texture2D getHeightMap() {
+		return heightMap;
+	}
+
+	@Override
+	public void setHeightMap(Texture2D heightMap) {
+		this.heightMap = heightMap;
 	}
 
 

--- a/src/main/java/engine/object/terrain/terrain/MappedTerrain.java
+++ b/src/main/java/engine/object/terrain/terrain/MappedTerrain.java
@@ -34,6 +34,8 @@ public class MappedTerrain extends ATerrain implements ITerrain {
 	private Mesh model;
 	private TerrainTexturePack texturePack;
 	private Texture2D blendMap;
+	private Texture2D heightMap;
+	private Texture2D normalMap;
 	private String heightMapName;
 	private boolean isProcedureGenerated = false;
 	private boolean isVisible = true;
@@ -258,6 +260,26 @@ public class MappedTerrain extends ATerrain implements ITerrain {
 		height /= MAX_PIXEL_COLOUR / 2f;
 		height *= MAX_HEIGHT;
 		return height;
+	}
+
+	@Override
+	public Texture2D getHeightMap() {
+		return heightMap;
+	}
+
+	@Override
+	public void setHeightMap(Texture2D heightMap) {
+		this.heightMap = heightMap;
+	}
+
+	@Override
+	public Texture2D getNormalMap() {
+		return normalMap;
+	}
+
+	@Override
+	public void setNormalMap(Texture2D normalMap) {
+		this.normalMap = normalMap;		
 	}
 
 

--- a/src/main/java/engine/object/terrain/terrain/ProceduredTerrain.java
+++ b/src/main/java/engine/object/terrain/terrain/ProceduredTerrain.java
@@ -1,11 +1,6 @@
 package object.terrain.terrain;
 
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL30;
-import org.lwjgl.opengl.GL42;
-
 import object.camera.FreeCamera;
-import object.camera.ICamera;
 import object.terrain.generator.HeightsGenerator;
 import object.texture.Texture2D;
 import object.texture.terrain.TerrainTexturePack;
@@ -265,7 +260,7 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 				indices[pointer++] = bottomRight;
 			}
 		}
-		return Loader.getInstance().getVertexLoader().loadToVAO(vertices, textureCoords, normals, indices);
+		return Loader.getInstance().getVertexLoader().loadToVAOwithTBO(vertices, textureCoords, indices);
 	}
 	
 	private Mesh generateWithProcedure(float amp, int oct, float rough, int seed) {
@@ -309,16 +304,7 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 				indices[pointer++] = bottomRight;
 			}
 		}
-		return Loader.getInstance().getVertexLoader().loadToVAO(vertices, textureCoords, normals, indices);
-	}
-	
-	private Texture2D generateHeightMap() {
-		int size = 10;
-		Texture2D heightMap = Texture2D.create(size, size, 1, false);
-		GL42.glTexStorage2D(GL11.GL_TEXTURE_2D,	(int) (Math.log(size) / Math.log(2)), GL30.GL_RGBA32F, size, size);
-		
-		this.heightMap = heightMap;
-		return heightMap;
+		return Loader.getInstance().getVertexLoader().loadToVAOwithTBO(vertices, textureCoords, indices);
 	}
 
 	private float getHeight(int x, int z, HeightsGenerator generator) {
@@ -333,6 +319,16 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 		Vector3f normal = new Vector3f(heightL - heightR, 2f, heightD - heightU);
 		normal.normalize();
 		return normal;
+	}
+
+	@Override
+	public Texture2D getHeightMap() {
+		return this.heightMap;
+	}
+	
+	@Override
+	public void setHeightMap(Texture2D heightMap) {
+		this.heightMap = heightMap;
 	}
 
 }

--- a/src/main/java/engine/object/terrain/terrain/ProceduredTerrain.java
+++ b/src/main/java/engine/object/terrain/terrain/ProceduredTerrain.java
@@ -1,11 +1,6 @@
 package object.terrain.terrain;
 
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL30;
-import org.lwjgl.opengl.GL42;
-
 import object.camera.FreeCamera;
-import object.camera.ICamera;
 import object.terrain.generator.HeightsGenerator;
 import object.texture.Texture2D;
 import object.texture.terrain.TerrainTexturePack;
@@ -29,6 +24,7 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 	private TerrainTexturePack texturePack;
 	private Texture2D blendMap;
 	private Texture2D heightMap;
+	private Texture2D normalMap;
 	
 	private String heightMapName;
 	private boolean isProcedureGenerated = true;
@@ -230,7 +226,7 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 		heights = new float[VERTEX_COUNT][VERTEX_COUNT];
 		int count = VERTEX_COUNT * VERTEX_COUNT;
 		float[] vertices = new float[count * 3];
-		float[] normals = new float[count * 3];
+//		float[] normals = new float[count * 3];
 		float[] textureCoords = new float[count * 2];
 		int[] indices = new int[6 * (VERTEX_COUNT - 1) * (VERTEX_COUNT - 1)];
 		int vertexPointer = 0;
@@ -241,10 +237,10 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 				heights[j][i] = height;
 				vertices[vertexPointer * 3 + 1] = height;
 				vertices[vertexPointer * 3 + 2] = i / ((float) VERTEX_COUNT - 1) * ITerrain.TERRAIN_SIZE;
-				Vector3f normal = calculateNormal(j, i, generator);
-				normals[vertexPointer * 3] = normal.x;
-				normals[vertexPointer * 3 + 1] = normal.y;
-				normals[vertexPointer * 3 + 2] = normal.z;
+//				Vector3f normal = calculateNormal(j, i, generator);
+//				normals[vertexPointer * 3] = normal.x;
+//				normals[vertexPointer * 3 + 1] = normal.y;
+//				normals[vertexPointer * 3 + 2] = normal.z;
 				textureCoords[vertexPointer * 2] = j / ((float) VERTEX_COUNT - 1);
 				textureCoords[vertexPointer * 2 + 1] = i / ((float) VERTEX_COUNT - 1);
 				vertexPointer++;
@@ -265,7 +261,7 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 				indices[pointer++] = bottomRight;
 			}
 		}
-		return Loader.getInstance().getVertexLoader().loadToVAO(vertices, textureCoords, normals, indices);
+		return Loader.getInstance().getVertexLoader().loadToVAOwithTBO(vertices, textureCoords, indices);
 	}
 	
 	private Mesh generateWithProcedure(float amp, int oct, float rough, int seed) {
@@ -274,7 +270,7 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 		heights = new float[VERTEX_COUNT][VERTEX_COUNT];
 		int count = VERTEX_COUNT * VERTEX_COUNT;
 		float[] vertices = new float[count * 3];
-		float[] normals = new float[count * 3];
+//		float[] normals = new float[count * 3];
 		float[] textureCoords = new float[count * 2];
 		int[] indices = new int[6 * (VERTEX_COUNT - 1) * (VERTEX_COUNT - 1)];
 		int vertexPointer = 0;
@@ -285,10 +281,10 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 				heights[j][i] = height;
 				vertices[vertexPointer * 3 + 1] = height;
 				vertices[vertexPointer * 3 + 2] = i / ((float) VERTEX_COUNT - 1) * ITerrain.TERRAIN_SIZE;
-				Vector3f normal = calculateNormal(j, i, generator);
-				normals[vertexPointer * 3] = normal.x;
-				normals[vertexPointer * 3 + 1] = normal.y;
-				normals[vertexPointer * 3 + 2] = normal.z;
+//				Vector3f normal = calculateNormal(j, i, generator);
+//				normals[vertexPointer * 3] = normal.x;
+//				normals[vertexPointer * 3 + 1] = normal.y;
+//				normals[vertexPointer * 3 + 2] = normal.z;
 				textureCoords[vertexPointer * 2] = j / ((float) VERTEX_COUNT - 1);
 				textureCoords[vertexPointer * 2 + 1] = i / ((float) VERTEX_COUNT - 1);
 				vertexPointer++;
@@ -309,16 +305,7 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 				indices[pointer++] = bottomRight;
 			}
 		}
-		return Loader.getInstance().getVertexLoader().loadToVAO(vertices, textureCoords, normals, indices);
-	}
-	
-	private Texture2D generateHeightMap() {
-		int size = 10;
-		Texture2D heightMap = Texture2D.create(size, size, 1, false);
-		GL42.glTexStorage2D(GL11.GL_TEXTURE_2D,	(int) (Math.log(size) / Math.log(2)), GL30.GL_RGBA32F, size, size);
-		
-		this.heightMap = heightMap;
-		return heightMap;
+		return Loader.getInstance().getVertexLoader().loadToVAOwithTBO(vertices, textureCoords, indices);
 	}
 
 	private float getHeight(int x, int z, HeightsGenerator generator) {
@@ -333,6 +320,26 @@ public class ProceduredTerrain extends ATerrain implements ITerrain {
 		Vector3f normal = new Vector3f(heightL - heightR, 2f, heightD - heightU);
 		normal.normalize();
 		return normal;
+	}
+
+	@Override
+	public Texture2D getHeightMap() {
+		return this.heightMap;
+	}
+	
+	@Override
+	public void setHeightMap(Texture2D heightMap) {
+		this.heightMap = heightMap;
+	}
+
+	@Override
+	public Texture2D getNormalMap() {
+		return normalMap;
+	}
+
+	@Override
+	public void setNormalMap(Texture2D normalMap) {
+		this.normalMap = normalMap;		
 	}
 
 }

--- a/src/main/java/engine/object/terrain/terrain/TerrainQuadTree.java
+++ b/src/main/java/engine/object/terrain/terrain/TerrainQuadTree.java
@@ -6,7 +6,6 @@ import core.settings.EngineSettings;
 import manager.octree.Node;
 import object.camera.ICamera;
 import primitive.buffer.Loader;
-import primitive.buffer.PatchVAO;
 import primitive.buffer.VAO;
 import tool.EngineUtils;
 import tool.math.Matrix4f;
@@ -21,9 +20,7 @@ public class TerrainQuadTree extends Node {
 	
 	public TerrainQuadTree(ICamera camera) {
 		float[] positions = this.generateVertexData();
-		float[] coordinates = this.generateVertexData2D();
-		float[] normals = this.generateNormalData();
-		this.vao = Loader.getInstance().getVertexLoader().loadPatchToVAO(positions, coordinates, normals, 16);
+		this.vao = Loader.getInstance().getVertexLoader().loadPatchToVAO(positions, 16);
 		
 		for(int i = 0; i < rootNodes; i++) {
 			for(int j = 0; j < rootNodes; j++) {
@@ -39,107 +36,6 @@ public class TerrainQuadTree extends Node {
 		for(Node node: getChildren()) {
 			((TerrainNode) node).updateQuadTree(camera);
 		}
-	}
-	
-	private float[] generateNormalData() {
-	Vector3f[] normals = new Vector3f[16];
-		
-		int index = 0;
-		
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		normals[index++] = new Vector3f(1, 1, 1);
-		
-		Object[] normArray = Stream.of(normals)
-				.flatMap(vertex -> Stream.of(vertex.x, vertex.y))
-				.toArray();
-		
-		float[] norms = EngineUtils.toFloatArray(normArray);
-		
-		return norms;
-	}
-	
-	private float[] generateCoordinateData() {
-		Vector2f[] coordinates = new Vector2f[16];
-		
-		int index = 0;
-		
-		coordinates[index++] = new Vector2f(0,0);
-		coordinates[index++] = new Vector2f(1,1);
-		coordinates[index++] = new Vector2f(0,0);
-		coordinates[index++] = new Vector2f(1,1);
-		
-		coordinates[index++] = new Vector2f(0,0);
-		coordinates[index++] = new Vector2f(1,1);
-		coordinates[index++] = new Vector2f(0,0);
-		coordinates[index++] = new Vector2f(1,1);
-		
-		coordinates[index++] = new Vector2f(0,0);
-		coordinates[index++] = new Vector2f(1,1);
-		coordinates[index++] = new Vector2f(0,0);
-		coordinates[index++] = new Vector2f(1,1);
-		
-		coordinates[index++] = new Vector2f(0,0);
-		coordinates[index++] = new Vector2f(1,1);
-		coordinates[index++] = new Vector2f(0,0);
-		coordinates[index++] = new Vector2f(1,1);
-		
-		Object[] coordArray = Stream.of(coordinates)
-				.flatMap(vertex -> Stream.of(vertex.x, vertex.y))
-				.toArray();
-		
-		float[] coords = EngineUtils.toFloatArray(coordArray);
-		
-		return coords;
-	}
-	
-	private float[] generateVertexData2D() {
-		Vector2f[] vertices = new Vector2f[16];
-		
-		int index = 0;
-		
-		vertices[index++] = new Vector2f(0, 0);
-		vertices[index++] = new Vector2f(0.333f, 0);
-		vertices[index++] = new Vector2f(0.666f, 0);
-		vertices[index++] = new Vector2f(1, 0);
-		
-		vertices[index++] = new Vector2f(0, 0.333f);
-		vertices[index++] = new Vector2f(0.333f, 0.333f);
-		vertices[index++] = new Vector2f(0.666f, 0.333f);
-		vertices[index++] = new Vector2f(1, 0.333f);
-		
-		vertices[index++] = new Vector2f(0, 0.666f);
-		vertices[index++] = new Vector2f(0.333f, 0.666f);
-		vertices[index++] = new Vector2f(0.666f, 0.666f);
-		vertices[index++] = new Vector2f(1, 0.666f);
-		
-		vertices[index++] = new Vector2f(0, 1);
-		vertices[index++] = new Vector2f(0.333f, 1);
-		vertices[index++] = new Vector2f(0.666f, 1);
-		vertices[index++] = new Vector2f(1, 1);
-		
-		Object[] positionArray = Stream.of(vertices)
-				.flatMap(vertex -> Stream.of(vertex.x, vertex.y))
-				.toArray();
-		
-		float[] positions = EngineUtils.toFloatArray(positionArray);
-		return positions;
 	}
 
 	private float[] generateVertexData() {

--- a/src/main/java/engine/object/texture/TBO.java
+++ b/src/main/java/engine/object/texture/TBO.java
@@ -1,0 +1,88 @@
+package object.texture;
+
+import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.lwjgl.opengl.GL11.glDeleteTextures;
+import static org.lwjgl.opengl.GL31.GL_TEXTURE_BUFFER;
+import static org.lwjgl.opengl.GL11.GL_UNPACK_ALIGNMENT;
+import static org.lwjgl.opengl.GL13.GL_TEXTURE0;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL31;
+
+import primitive.buffer.VBO;
+
+/**
+ * Texture buffer object.<br>
+ * Can be used to store vertex buffer object data as buffer texture.
+ *  
+ * @author homelleon
+ * @version 1.0
+ */
+public class TBO {
+	
+	private String name;
+	private int id;
+	private int size;
+	
+	/**
+	 * Creates texture buffer object as texture from vertex buffer object.
+	 * 
+	 * @param name - String name
+	 * @param vbo - GL_TEXTURE_BUFFER-type vertex buffer object
+	 * @param storageType - int type of data storage
+	 * @return {@link TBO} texture buffer object
+	 */
+	public static TBO create(String name, VBO vbo, int storageType) {
+		TBO texture = new TBO();
+		texture.name = name;
+		texture.size = vbo.getSize();
+		GL15.glBindBuffer(GL_TEXTURE_BUFFER, vbo.getId());
+		texture.id = GL11.glGenTextures();
+		GL11.glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+		GL31.glTexBuffer(GL_TEXTURE_BUFFER, storageType, vbo.getId());
+		GL15.glBindBuffer(GL_TEXTURE_BUFFER, 0);
+		unbind();
+		return texture;
+	}
+	
+	private TBO(){}
+	
+	public void bind() {
+		glBindTexture(GL_TEXTURE_BUFFER, id);
+	}
+	
+	public void bind(int location) {
+		active(location);
+		glBindTexture(GL_TEXTURE_BUFFER, id);
+	}
+	
+	public static void active(int location) {
+		if(location >= 0 && location < 31) {
+			GL13.glActiveTexture(GL_TEXTURE0 + location);
+		} else {
+			throw new IndexOutOfBoundsException("Incorrect location at texture activation!");
+		}			
+	}
+	
+	public void delete() {
+		glDeleteTextures(id);
+	}
+	
+	public static void unbind() {
+		glBindTexture(GL_TEXTURE_BUFFER, 0);
+	}
+	
+	public int getId() {
+		return id;
+	}
+
+	public String getName()	{
+		return name;
+	}
+
+	public int getSize() {
+		return size;
+	}
+}

--- a/src/main/java/engine/object/texture/Texture2D.java
+++ b/src/main/java/engine/object/texture/Texture2D.java
@@ -6,9 +6,9 @@ import static org.lwjgl.opengl.GL11.glDeleteTextures;
 import static org.lwjgl.opengl.GL11.glGenTextures;
 
 import org.lwjgl.opengl.GL11;
-import org.newdawn.slick.opengl.Texture;
-
 import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL31;
+import org.newdawn.slick.opengl.Texture;
 
 import primitive.buffer.TextureBufferLoader;
 
@@ -23,7 +23,7 @@ public class Texture2D {
 	
 	public static Texture2D create(int width, int height, int numberOfRows, boolean hasTransparency) {
 		Texture2D texture = new Texture2D();
-		texture.id = GL11.glGenTextures();
+		texture.generate();
 		texture.width = width;
 		texture.height = height;
 		texture.numberOfRows = numberOfRows;
@@ -63,17 +63,17 @@ public class Texture2D {
 		glBindTexture(GL_TEXTURE_2D, 0);
 	}
 	
-	public static void noFilter() {
+	public void noFilter() {
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
 	}
 	
-	public static void bilinearFilter() {
+	public void bilinearFilter() {
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
 	}
 	
-	public static void repeatWrap() {
+	public void repeatWrap() {
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL11.GL_REPEAT);
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL11.GL_REPEAT);
 	}
@@ -110,7 +110,7 @@ public class Texture2D {
 		this.hasTransparency = hasTransparency;
 	}
 	
-	private void active(int location) {
+	public static void active(int location) {
 		if(location >= 0 && location < 31) {
 			GL13.glActiveTexture(GL13.GL_TEXTURE0 + location);
 		} else {

--- a/src/main/java/engine/object/texture/Texture2D.java
+++ b/src/main/java/engine/object/texture/Texture2D.java
@@ -7,9 +7,11 @@ import static org.lwjgl.opengl.GL11.glGenTextures;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL14;
 import org.lwjgl.opengl.GL31;
 import org.newdawn.slick.opengl.Texture;
 
+import primitive.buffer.Loader;
 import primitive.buffer.TextureBufferLoader;
 
 public class Texture2D {
@@ -62,6 +64,7 @@ public class Texture2D {
 	
 	public void generate() {
 		id = glGenTextures();
+		Loader.getInstance().getTextureLoader().addTexture(this);
 	}
 	
 	public void delete() {
@@ -85,6 +88,11 @@ public class Texture2D {
 	public void repeatWrap() {
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL11.GL_REPEAT);
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL11.GL_REPEAT);
+	}
+	
+	public void mirrorRepeatWrap() {
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL14.GL_MIRRORED_REPEAT);
+		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL14.GL_MIRRORED_REPEAT);
 	}
 	
 	public int getId() {

--- a/src/main/java/engine/object/texture/Texture2D.java
+++ b/src/main/java/engine/object/texture/Texture2D.java
@@ -6,9 +6,9 @@ import static org.lwjgl.opengl.GL11.glDeleteTextures;
 import static org.lwjgl.opengl.GL11.glGenTextures;
 
 import org.lwjgl.opengl.GL11;
-import org.newdawn.slick.opengl.Texture;
-
 import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL31;
+import org.newdawn.slick.opengl.Texture;
 
 import primitive.buffer.TextureBufferLoader;
 
@@ -23,7 +23,7 @@ public class Texture2D {
 	
 	public static Texture2D create(int width, int height, int numberOfRows, boolean hasTransparency) {
 		Texture2D texture = new Texture2D();
-		texture.id = GL11.glGenTextures();
+		texture.generate();
 		texture.width = width;
 		texture.height = height;
 		texture.numberOfRows = numberOfRows;
@@ -46,6 +46,15 @@ public class Texture2D {
 		glBindTexture(GL_TEXTURE_2D, id);
 	}
 	
+	public void bindAsBuffer() {
+		glBindTexture(GL31.GL_TEXTURE_BUFFER, id);
+	}
+	
+	public void bindAsBuffer(int location) {
+		active(location);
+		glBindTexture(GL31.GL_TEXTURE_BUFFER, id);
+	}
+	
 	public void bind(int location) {
 		active(location);
 		glBindTexture(GL_TEXTURE_2D, id);
@@ -61,6 +70,10 @@ public class Texture2D {
 	
 	public static void unbind() {
 		glBindTexture(GL_TEXTURE_2D, 0);
+	}
+	
+	public static void unbindAsBuffer() {
+		glBindTexture(GL31.GL_TEXTURE_BUFFER, 0);
 	}
 	
 	public static void noFilter() {
@@ -110,7 +123,7 @@ public class Texture2D {
 		this.hasTransparency = hasTransparency;
 	}
 	
-	private void active(int location) {
+	public static void active(int location) {
 		if(location >= 0 && location < 31) {
 			GL13.glActiveTexture(GL13.GL_TEXTURE0 + location);
 		} else {

--- a/src/main/java/engine/primitive/buffer/BufferLoader.java
+++ b/src/main/java/engine/primitive/buffer/BufferLoader.java
@@ -78,13 +78,11 @@ public class BufferLoader {
 		return vao;
 	}
 	
-	public VAO loadPatchToVAO(float[] positions, float[] textureCoords, float[] normals, int patchSize) {
+	public VAO loadPatchToVAO(float[] positions, int patchSize) {
 		VAO vao = VAO.create();
 		this.vaos.add(vao);
 		vao.bind();
 		vao.createPatchAttribute(0, 3, positions, patchSize);
-		vao.createPatchAttribute(1, 2, textureCoords, patchSize);
-		vao.createPatchAttribute(2, 3, normals, patchSize);
 		VAO.unbind();
 		return vao;
 	}

--- a/src/main/java/engine/primitive/buffer/BufferLoader.java
+++ b/src/main/java/engine/primitive/buffer/BufferLoader.java
@@ -117,6 +117,45 @@ public class BufferLoader {
 		BoundingBox box = new BoundingBox(positions);
 		return new Mesh(vao, indices.length, sphere, box);
 	}
+	
+	public Mesh loadToVAOwithSSBO(float[] positions, float[] textureCoords, int[] indices) {
+		VAO vao = VAO.create();
+		this.vaos.add(vao);
+		vao.bind();
+		vao.createIndexBuffer(indices);
+		vao.createSSBOAttribute(0, 3, positions);
+		vao.createAttribute(1, 2, textureCoords);
+		VAO.unbind();
+		BoundingSphere sphere = new BoundingSphere(positions);
+		BoundingBox box = new BoundingBox(positions);
+		return new Mesh(vao, indices.length, sphere, box);
+	}
+	
+	public Mesh loadToVAOwithTBO(float[] positions, float[] textureCoords, int[] indices) {
+		VAO vao = VAO.create();
+		this.vaos.add(vao);
+		vao.bind();
+		vao.createIndexBuffer(indices);
+		vao.createTBOAttribute(0, 3, positions);
+		vao.createAttribute(1, 2, textureCoords);
+		VAO.unbind();
+		BoundingSphere sphere = new BoundingSphere(positions);
+		BoundingBox box = new BoundingBox(positions);
+		return new Mesh(vao, indices.length, sphere, box);
+	}
+	
+	public Mesh loadToVAOwithDispatchInderect(float[] positions, float[] textureCoords, int[] indices) {
+		VAO vao = VAO.create();
+		this.vaos.add(vao);
+		vao.bind();
+		vao.createIndexBuffer(indices);
+		vao.createDispatchAttribute(0, 3, positions);
+		vao.createAttribute(1, 2, textureCoords);
+		VAO.unbind();
+		BoundingSphere sphere = new BoundingSphere(positions);
+		BoundingBox box = new BoundingBox(positions);
+		return new Mesh(vao, indices.length, sphere, box);
+	} 
 
 	/**
 	 * Loads verticies buffer object to use with verticies array object.

--- a/src/main/java/engine/primitive/buffer/TextureBufferLoader.java
+++ b/src/main/java/engine/primitive/buffer/TextureBufferLoader.java
@@ -212,6 +212,10 @@ public class TextureBufferLoader {
 		return new TextureData(buffer, width, height);
 	}
 	
+	public void addTexture(Texture2D texture) {
+		textures2D.put(texture.getName(), texture);
+	}
+	
 	public void clean() {
 		textures2D.values().forEach(Texture2D::delete);
 		textures3D.values().forEach(texture -> GL11.glDeleteTextures(texture));

--- a/src/main/java/engine/primitive/buffer/VAO.java
+++ b/src/main/java/engine/primitive/buffer/VAO.java
@@ -7,7 +7,11 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
 import org.lwjgl.opengl.GL20;
 import org.lwjgl.opengl.GL30;
+import org.lwjgl.opengl.GL31;
 import org.lwjgl.opengl.GL40;
+import org.lwjgl.opengl.GL43;
+
+import object.texture.Texture2D;
 
 public class VAO {
 
@@ -71,6 +75,32 @@ public class VAO {
 		dataVbos.add(dataVbo);
 	}
 	
+	public void createSSBOAttribute(int attribute, int attrSize, float[] data) {
+		VBO dataVBO = VBO.create(GL43.GL_SHADER_STORAGE_BUFFER);
+		dataVBO.bind();
+		dataVBO.storeData(data);
+		dataVBO.bindBase(0);		
+		//GL20.glVertexAttribPointer(attribute, attrSize, GL11.GL_FLOAT, false, attrSize * BYTES_PER_FLOAT, 0);
+		dataVBO.unbind();
+		dataVbos.add(dataVBO);
+	}
+	
+	public void createTBOAttribute(int attribute, int attrSize, float[] data) {
+		VBO dataVBO = VBO.create(GL31.GL_TEXTURE_BUFFER);
+		dataVBO.bind();
+		dataVBO.storeData(data);
+		dataVBO.unbind();
+		dataVbos.add(dataVBO);
+	}
+	
+	public void createDispatchAttribute(int attribute, int attrSize, float[] data) {
+		VBO dataVBO = VBO.create(GL43.GL_DISPATCH_INDIRECT_BUFFER);
+		dataVBO.bind();
+		dataVBO.storeData(data);
+		dataVBO.unbind();
+		dataVbos.add(dataVBO);
+	}
+	
 
 	public void createIntAttribute(int attribute, int attrSize, int[] data) {
 		VBO dataVbo = VBO.create(GL15.GL_ARRAY_BUFFER);
@@ -79,6 +109,10 @@ public class VAO {
 		GL30.glVertexAttribIPointer(attribute, attrSize, GL11.GL_INT, attrSize * BYTES_PER_INT, 0);
 		dataVbo.unbind();
 		dataVbos.add(dataVbo);
+	}
+	
+	public List<VBO> getVBOs() {
+		return this.dataVbos;
 	}
 
 	public void delete() {

--- a/src/main/java/engine/primitive/buffer/VBO.java
+++ b/src/main/java/engine/primitive/buffer/VBO.java
@@ -5,11 +5,13 @@ import java.nio.IntBuffer;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL30;
 
 public class VBO {
 
 	private final int vboId;
 	private final int type;
+	private int size;
 
 	private VBO(int vboId, int type) {
 		this.vboId = vboId;
@@ -23,6 +25,10 @@ public class VBO {
 
 	public void bind() {
 		GL15.glBindBuffer(type, vboId);
+	}
+	
+	public void bindBase(int layout) {
+		GL30.glBindBufferBase(type, layout, vboId);
 	}
 
 	public void unbind() {
@@ -38,14 +44,16 @@ public class VBO {
 	}
 
 	public void storeData(float[] data) {
-		FloatBuffer buffer = BufferUtils.createFloatBuffer(data.length);
+		size = data.length;
+		FloatBuffer buffer = BufferUtils.createFloatBuffer(size);
 		buffer.put(data);
 		buffer.flip();
 		storeData(buffer);
 	}
 
 	public void storeData(int[] data) {
-		IntBuffer buffer = BufferUtils.createIntBuffer(data.length);
+		size = data.length;
+		IntBuffer buffer = BufferUtils.createIntBuffer(size);
 		buffer.put(data);
 		buffer.flip();
 		storeData(buffer);
@@ -61,6 +69,14 @@ public class VBO {
 
 	public void storeData(FloatBuffer data) {
 		GL15.glBufferData(type, data, GL15.GL_STATIC_DRAW);
+	}
+	
+	public int getId() {
+		return this.vboId;
+	}
+	
+	public int getSize() {
+		return size;
 	}
 
 	public void delete() {

--- a/src/main/java/engine/renderer/gpgpu/HeightMapRenderer.java
+++ b/src/main/java/engine/renderer/gpgpu/HeightMapRenderer.java
@@ -1,15 +1,13 @@
 package renderer.gpgpu;
 
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
-import org.lwjgl.opengl.GL14;
 import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL21;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.opengl.GL31;
 import org.lwjgl.opengl.GL42;
 import org.lwjgl.opengl.GL43;
 
+import object.texture.TBO;
 import object.texture.Texture2D;
 import primitive.buffer.VAO;
 import shader.gpgpu.HeightMapShader;
@@ -19,27 +17,32 @@ public class HeightMapRenderer {
 	private HeightMapShader shader;
 	private VAO vao;
 	private Texture2D heightMap;
+	private TBO positionMap;
 	private int size;
+
 	
 	public HeightMapRenderer(int size, VAO vao) {
 		this.size = size;
 		this.vao = vao;
 		heightMap = Texture2D.create(size, size, 1, false);
+		heightMap.bind();
 		GL42.glTexStorage2D(GL11.GL_TEXTURE_2D, (int) (Math.log(size) / Math.log(2)), GL30.GL_RGBA32F, size, size);
 		Texture2D.unbind();
+		
+		positionMap = TBO.create("positionMap", vao.getVBOs().get(0), GL30.GL_RGB32F);		
 		shader = new HeightMapShader();
 	}
 	
 	public void render() {
 		shader.start();
-		vao.bind(0);
-		GL30.glBindBufferBase(GL31.GL_UNIFORM_BUFFER, index, buffer);
 		shader.loadMapSize(size);
+		positionMap.bind(1);
 		GL42.glBindImageTexture(0, heightMap.getId(), 0, false, 0, GL15.GL_WRITE_ONLY, GL30.GL_RGBA32F);
-		GL43.glDispatchCompute(size / 16, size / 16, 1);
+		int workGroupCount = (int) (size); 
+		GL43.glDispatchCompute(workGroupCount, workGroupCount, 1);
+		GL42.glMemoryBarrier(GL43.GL_SHADER_STORAGE_BARRIER_BIT);
 		GL11.glFinish();
-		Texture2D.bilinearFilter();
-		shader.stop();		
+		shader.stop();
 	}
 	
 	public Texture2D getHeightMap() {
@@ -49,7 +52,6 @@ public class HeightMapRenderer {
 	public void clean() {
 		shader.stop();
 		shader.clean();
-		heightMap.delete();
 	}
 
 }

--- a/src/main/java/engine/renderer/gpgpu/HeightMapRenderer.java
+++ b/src/main/java/engine/renderer/gpgpu/HeightMapRenderer.java
@@ -1,21 +1,55 @@
 package renderer.gpgpu;
 
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+import org.lwjgl.opengl.GL14;
+import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL21;
+import org.lwjgl.opengl.GL30;
+import org.lwjgl.opengl.GL31;
+import org.lwjgl.opengl.GL42;
+import org.lwjgl.opengl.GL43;
+
 import object.texture.Texture2D;
+import primitive.buffer.VAO;
+import shader.gpgpu.HeightMapShader;
 
 public class HeightMapRenderer {
 	
+	private HeightMapShader shader;
+	private VAO vao;
 	private Texture2D heightMap;
+	private int size;
 	
-	public HeightMapRenderer(int size) {
-		
+	public HeightMapRenderer(int size, VAO vao) {
+		this.size = size;
+		this.vao = vao;
+		heightMap = Texture2D.create(size, size, 1, false);
+		GL42.glTexStorage2D(GL11.GL_TEXTURE_2D, (int) (Math.log(size) / Math.log(2)), GL30.GL_RGBA32F, size, size);
+		Texture2D.unbind();
+		shader = new HeightMapShader();
 	}
 	
 	public void render() {
-		
+		shader.start();
+		vao.bind(0);
+		GL30.glBindBufferBase(GL31.GL_UNIFORM_BUFFER, index, buffer);
+		shader.loadMapSize(size);
+		GL42.glBindImageTexture(0, heightMap.getId(), 0, false, 0, GL15.GL_WRITE_ONLY, GL30.GL_RGBA32F);
+		GL43.glDispatchCompute(size / 16, size / 16, 1);
+		GL11.glFinish();
+		Texture2D.bilinearFilter();
+		shader.stop();		
+	}
+	
+	public Texture2D getHeightMap() {
+		return heightMap;
 	}
 	
 	public void clean() {
-		
+		shader.stop();
+		shader.clean();
+		heightMap.delete();
 	}
 
 }

--- a/src/main/java/engine/renderer/gpgpu/HeightMapRenderer.java
+++ b/src/main/java/engine/renderer/gpgpu/HeightMapRenderer.java
@@ -14,7 +14,6 @@ import shader.gpgpu.HeightMapShader;
 public class HeightMapRenderer {
 	
 	private HeightMapShader shader;
-	private VAO vao;
 	private Texture2D heightMap;
 	private TBO positionMap;
 	private int size;
@@ -22,7 +21,6 @@ public class HeightMapRenderer {
 	
 	public HeightMapRenderer(int size, VAO vao) {
 		this.size = size;
-		this.vao = vao;		
 		
 		heightMap = Texture2D.create(size, size, 1, false);
 		heightMap.bind();

--- a/src/main/java/engine/renderer/gpgpu/NormalMapRenderer.java
+++ b/src/main/java/engine/renderer/gpgpu/NormalMapRenderer.java
@@ -13,6 +13,7 @@ public class NormalMapRenderer {
 	
 	private NormalMapShader shader;
 	private Texture2D normalMap;
+	private Texture2D heightMap;
 	private int size;
 	private float strength;
 	
@@ -20,26 +21,33 @@ public class NormalMapRenderer {
 		this.size = size;
 		normalMap = Texture2D.create(size, size, 1, false);
 		normalMap.bind();
+		normalMap.bilinearFilter();
 		GL42.glTexStorage2D(GL11.GL_TEXTURE_2D,	(int) (Math.log(size) / Math.log(2)), GL30.GL_RGBA32F, size, size);
-		Texture2D.unbind();
 		shader = new NormalMapShader();
+		shader.start();
+		shader.connectTextureUnits();
+		shader.stop();
 	}
 	
-	public void render(Texture2D heightMap) {
-		
+	public void render() {		
 		shader.start();
-		heightMap.bind(0);
 		shader.updateUniforms(size, strength);
 		GL42.glBindImageTexture(0, normalMap.getId(), 0, false, 0, GL15.GL_WRITE_ONLY, GL30.GL_RGBA32F);
+		heightMap.bind(0);
 		GL43.glDispatchCompute(size / 16, size / 16, 1);
+		GL42.glMemoryBarrier(GL43.GL_SHADER_STORAGE_BARRIER_BIT);
 		GL11.glFinish();
-		Texture2D.bilinearFilter();
-		shader.stop();
-		
+		normalMap.bind();
+		normalMap.bilinearFilter();
+		shader.stop();		
 	}
 	
 	public Texture2D getNormalMap() {
-		return this.normalMap;
+		return normalMap;
+	}
+	
+	public void setHeightMap(Texture2D heightMap) {
+		this.heightMap = heightMap;
 	}
 	
 	public void setStrength(float strength) {

--- a/src/main/java/engine/renderer/gui/texture/GUITextureRenderer.java
+++ b/src/main/java/engine/renderer/gui/texture/GUITextureRenderer.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import org.lwjgl.opengl.GL11;
 
 import object.gui.texture.GUITexture;
+import object.texture.Texture2D;
 import primitive.buffer.Loader;
 import primitive.buffer.VAO;
 import primitive.model.Mesh;

--- a/src/main/java/engine/renderer/main/MainRenderer.java
+++ b/src/main/java/engine/renderer/main/MainRenderer.java
@@ -83,10 +83,10 @@ public class MainRenderer implements IMainRenderer {
 		entityRendererManager.addPair(decorEntityRenderer, decorEntities);
 		this.terrainRenderer = new TerrainRenderer(projectionMatrix);
 		// height and normal map rendering
-		this.heightRenderer = new HeightMapRenderer(128, scene.getTerrains().getAll().iterator().next().getModel().getVAO());
+		this.heightRenderer = new HeightMapRenderer(512, scene.getTerrains().getAll().iterator().next().getModel().getVAO());
 		heightRenderer.render();
 		normalMapRenderer = new NormalMapRenderer(heightRenderer.getHeightMap().getWidth());
-		normalMapRenderer.setStrength(4);
+		normalMapRenderer.setStrength(10);
 		normalMapRenderer.setHeightMap(heightRenderer.getHeightMap());
 		normalMapRenderer.render();
 		// setting height and normal map

--- a/src/main/java/engine/renderer/main/MainRenderer.java
+++ b/src/main/java/engine/renderer/main/MainRenderer.java
@@ -78,16 +78,24 @@ public class MainRenderer implements IMainRenderer {
 		IEntityRenderer normalEntityRenderer = new NormalEntityRenderer(projectionMatrix);
 		IEntityRenderer decorEntityRenderer = new DecorEntityRenderer(projectionMatrix);
 		this.entityRendererManager = new EntityRendererManager();
-		this.entityRendererManager.addPair(texturedEntityRenderer, texturedEntities);
-		this.entityRendererManager.addPair(normalEntityRenderer, normalEntities);
-		this.entityRendererManager.addPair(decorEntityRenderer, decorEntities);
+		entityRendererManager.addPair(texturedEntityRenderer, texturedEntities);
+		entityRendererManager.addPair(normalEntityRenderer, normalEntities);
+		entityRendererManager.addPair(decorEntityRenderer, decorEntities);
 		this.terrainRenderer = new TerrainRenderer(projectionMatrix);
-		this.heightRenderer = new HeightMapRenderer(512, scene.getTerrains().getAll().iterator().next().getModel().getVAO());
+		// height and normal map rendering
+		this.heightRenderer = new HeightMapRenderer(128, scene.getTerrains().getAll().iterator().next().getModel().getVAO());
 		heightRenderer.render();
-		this.normalMapRenderer = new NormalMapRenderer(heightRenderer.getHeightMap().getWidth());
-		this.normalMapRenderer.setStrength(4);
-		this.normalMapRenderer.render(terrainRenderer.getHeightMap());
-		this.terrainRenderer.setNormalMap(this.normalMapRenderer.getNormalMap());
+		normalMapRenderer = new NormalMapRenderer(heightRenderer.getHeightMap().getWidth());
+		normalMapRenderer.setStrength(4);
+		normalMapRenderer.setHeightMap(heightRenderer.getHeightMap());
+		normalMapRenderer.render();
+		// setting height and normal map
+		scene.getTerrains().get("Terrain1").setHeightMap(heightRenderer.getHeightMap());
+		scene.getTerrains().get("Terrain1").setNormalMap(normalMapRenderer.getNormalMap());
+		// cleanup
+		heightRenderer.clean();
+		normalMapRenderer.clean();
+		
 		this.skyboxRenderer = new SkyboxRenderer(projectionMatrix);
 		this.voxelRenderer = new VoxelRenderer(projectionMatrix);
 		this.boundingRenderer = new BoundingRenderer(projectionMatrix);

--- a/src/main/java/engine/renderer/main/MainRenderer.java
+++ b/src/main/java/engine/renderer/main/MainRenderer.java
@@ -82,12 +82,15 @@ public class MainRenderer implements IMainRenderer {
 		this.entityRendererManager.addPair(normalEntityRenderer, normalEntities);
 		this.entityRendererManager.addPair(decorEntityRenderer, decorEntities);
 		this.terrainRenderer = new TerrainRenderer(projectionMatrix);
-		this.heightRenderer = new HeightMapRenderer(512, scene.getTerrains().getAll().iterator().next().getModel().getVAO());
+		this.heightRenderer = new HeightMapRenderer(1024, scene.getTerrains().getAll().iterator().next().getModel().getVAO());
 		heightRenderer.render();
 		this.normalMapRenderer = new NormalMapRenderer(heightRenderer.getHeightMap().getWidth());
 		this.normalMapRenderer.setStrength(4);
-		this.normalMapRenderer.render(terrainRenderer.getHeightMap());
-		this.terrainRenderer.setNormalMap(this.normalMapRenderer.getNormalMap());
+		this.normalMapRenderer.render(heightRenderer.getHeightMap());
+		scene.getTerrains().get("Terrain1").setHeightMap(heightRenderer.getHeightMap());
+		terrainRenderer.setNormalMap(this.normalMapRenderer.getNormalMap());
+		this.heightRenderer.clean();
+		this.normalMapRenderer.clean();
 		this.skyboxRenderer = new SkyboxRenderer(projectionMatrix);
 		this.voxelRenderer = new VoxelRenderer(projectionMatrix);
 		this.boundingRenderer = new BoundingRenderer(projectionMatrix);

--- a/src/main/java/engine/renderer/main/MainRenderer.java
+++ b/src/main/java/engine/renderer/main/MainRenderer.java
@@ -29,6 +29,7 @@ import renderer.entity.IEntityRendererManager;
 import renderer.entity.NormalEntityRenderer;
 import renderer.entity.TexturedEntityRenderer;
 import renderer.environment.EnvironmentMapRenderer;
+import renderer.gpgpu.HeightMapRenderer;
 import renderer.gpgpu.NormalMapRenderer;
 import renderer.processor.ISceneProcessor;
 import renderer.processor.SceneProcessor;
@@ -44,6 +45,7 @@ public class MainRenderer implements IMainRenderer {
 	private Matrix4f projectionMatrix;
 	private Matrix4f normalDistProjectionMatrix;
 	private Matrix4f lowDistProjectionMatrix;
+	private HeightMapRenderer heightRenderer;
 	private NormalMapRenderer normalMapRenderer;
 	private TerrainRenderer terrainRenderer;
 	private SkyboxRenderer skyboxRenderer;
@@ -80,7 +82,9 @@ public class MainRenderer implements IMainRenderer {
 		this.entityRendererManager.addPair(normalEntityRenderer, normalEntities);
 		this.entityRendererManager.addPair(decorEntityRenderer, decorEntities);
 		this.terrainRenderer = new TerrainRenderer(projectionMatrix);
-		this.normalMapRenderer = new NormalMapRenderer(terrainRenderer.getHeightMap().getWidth());
+		this.heightRenderer = new HeightMapRenderer(512, scene.getTerrains().getAll().iterator().next().getModel().getVAO());
+		heightRenderer.render();
+		this.normalMapRenderer = new NormalMapRenderer(heightRenderer.getHeightMap().getWidth());
 		this.normalMapRenderer.setStrength(4);
 		this.normalMapRenderer.render(terrainRenderer.getHeightMap());
 		this.terrainRenderer.setNormalMap(this.normalMapRenderer.getNormalMap());

--- a/src/main/java/engine/renderer/scene/GameSceneRenderer.java
+++ b/src/main/java/engine/renderer/scene/GameSceneRenderer.java
@@ -15,7 +15,6 @@ import manager.scene.IObjectManager;
 import map.objectMap.ObjectMapManager;
 import map.writer.ILevelMapWriter;
 import map.writer.LevelMapXMLWriter;
-import object.gui.element.object.GUIObject;
 import object.gui.group.IGUIGroup;
 import object.gui.gui.GUI;
 import object.gui.gui.IGUI;
@@ -27,6 +26,7 @@ import object.input.KeyboardGame;
 import object.input.MousePicker;
 import object.particle.master.ParticleMaster;
 import object.scene.IScene;
+import object.texture.Texture2D;
 import object.water.WaterFrameBuffers;
 import renderer.main.MainRenderer;
 import renderer.water.WaterRenderer;
@@ -79,13 +79,17 @@ public class GameSceneRenderer implements ISceneRenderer {
 		this.scene.setMousePicker(mousePicker);
 		this.controls = new Controls();
 		
-		//GUI text info
+		// GUI text info
 		String fontName = "candara";
 		fpsText = createFPSText(Math.round(1 / DisplayManager.getFrameTimeSeconds()), fontName);
 		fpsText.setColor(1, 0, 0);
 		coordsText = createPickerCoordsText(mousePicker, fontName);
 		coordsText.setColor(1, 0, 0);
 		List<GUITexture> textureList = new ArrayList<GUITexture>();
+		// debug texture
+		Texture2D heightMap = scene.getTerrains().get("Terrain1").getHeightMap();
+		GUITexture debugTexture = new GUITexture("debugTexture", heightMap, new Vector2f(0,0), new Vector2f(0.5f,0.5f));
+		textureList.add(debugTexture);
 		List<GUIText> textList = new ArrayList<GUIText>();
 		textList.add(fpsText);
 		textList.add(coordsText);
@@ -94,6 +98,7 @@ public class GameSceneRenderer implements ISceneRenderer {
 		IGUI statusInterface = new GUI(statusGUIName, textureList, textList);
 		scene.getUserInterface().getGroups().createEmpty(statusGroupName);
 		scene.getUserInterface().getGroups().get(statusGroupName).add(statusInterface);
+		
 	}
 
 	@Override

--- a/src/main/java/engine/renderer/scene/GameSceneRenderer.java
+++ b/src/main/java/engine/renderer/scene/GameSceneRenderer.java
@@ -15,7 +15,6 @@ import manager.scene.IObjectManager;
 import map.objectMap.ObjectMapManager;
 import map.writer.ILevelMapWriter;
 import map.writer.LevelMapXMLWriter;
-import object.gui.element.object.GUIObject;
 import object.gui.group.IGUIGroup;
 import object.gui.gui.GUI;
 import object.gui.gui.IGUI;
@@ -27,6 +26,7 @@ import object.input.KeyboardGame;
 import object.input.MousePicker;
 import object.particle.master.ParticleMaster;
 import object.scene.IScene;
+import object.texture.Texture2D;
 import object.water.WaterFrameBuffers;
 import renderer.main.MainRenderer;
 import renderer.water.WaterRenderer;
@@ -79,13 +79,20 @@ public class GameSceneRenderer implements ISceneRenderer {
 		this.scene.setMousePicker(mousePicker);
 		this.controls = new Controls();
 		
-		//GUI text info
+		// GUI text info
 		String fontName = "candara";
 		fpsText = createFPSText(Math.round(1 / DisplayManager.getFrameTimeSeconds()), fontName);
 		fpsText.setColor(1, 0, 0);
 		coordsText = createPickerCoordsText(mousePicker, fontName);
 		coordsText.setColor(1, 0, 0);
 		List<GUITexture> textureList = new ArrayList<GUITexture>();
+		// debug texture
+		Texture2D heightMap = scene.getTerrains().get("Terrain1").getHeightMap();
+		Texture2D normalMap = scene.getTerrains().get("Terrain1").getNormalMap();
+		GUITexture debugTexture1 = new GUITexture("debugTexture1", heightMap, new Vector2f(-0.5f, 0), new Vector2f(0.3f, 0.3f));
+		GUITexture debugTexture2 = new GUITexture("debugTexture2", normalMap, new Vector2f(0.5f, 0), new Vector2f(0.3f, 0.3f));
+		textureList.add(debugTexture1);
+		textureList.add(debugTexture2);
 		List<GUIText> textList = new ArrayList<GUIText>();
 		textList.add(fpsText);
 		textList.add(coordsText);
@@ -94,6 +101,7 @@ public class GameSceneRenderer implements ISceneRenderer {
 		IGUI statusInterface = new GUI(statusGUIName, textureList, textList);
 		scene.getUserInterface().getGroups().createEmpty(statusGroupName);
 		scene.getUserInterface().getGroups().get(statusGroupName).add(statusInterface);
+		
 	}
 
 	@Override

--- a/src/main/java/engine/renderer/terrain/TerrainRenderer.java
+++ b/src/main/java/engine/renderer/terrain/TerrainRenderer.java
@@ -22,11 +22,8 @@ import tool.math.vector.Vector3f;
 public class TerrainRenderer {
 
 	private TerrainShader shader;
-	private Texture2D heightMap;
-	private Texture2D normalMap;
 
 	public TerrainRenderer(Matrix4f projectionMatrix) {
-		this.heightMap = new Texture2D("heightMap", EngineSettings.TEXTURE_HEIGHT_MAP_PATH + "heightMap.png");
 		this.shader = new TerrainShader();
 		shader.start();
 		shader.loadProjectionMatrix(projectionMatrix);
@@ -98,7 +95,7 @@ public class TerrainRenderer {
 		bindTexture(terrain);
 		shader.loadShineVariables(1, 0);
 		shader.loadWorldMatrix(terrainTree.getWorldMatrix());
-		Texture2D.repeatWrap();
+		terrain.getTexturePack().getBackgroundTexture().repeatWrap();
 	}
 
 	private void bindTexture(ITerrain terrain) {
@@ -108,8 +105,8 @@ public class TerrainRenderer {
 		texturePack.getGTexture().bind(2);
 		texturePack.getBTexture().bind(3);
 		terrain.getBlendMap().bind(4);
-		this.heightMap.bind(7);
-		this.normalMap.bind(8);
+		terrain.getHeightMap().bind(7);
+		terrain.getNormalMap().bind(8);
 	}
 
 	private void unbindTexture() {
@@ -123,14 +120,6 @@ public class TerrainRenderer {
 		Matrix4f transformationMatrix = Maths
 				.createTransformationMatrix(new Vector3f(EngineSettings.SCALE_XZ, EngineSettings.SCALE_Y, EngineSettings.SCALE_XZ), 0, 0, 0, 1);
 		shader.loadTranformationMatrix(transformationMatrix);
-	}
-	
-	public Texture2D getHeightMap() {
-		return this.heightMap;
-	}
-	
-	public void setNormalMap(Texture2D normalMap) {
-		this.normalMap = normalMap;
 	}
 
 }

--- a/src/main/java/engine/renderer/terrain/TerrainRenderer.java
+++ b/src/main/java/engine/renderer/terrain/TerrainRenderer.java
@@ -91,7 +91,7 @@ public class TerrainRenderer {
 	private void prepareTerrain(ITerrain terrain) {
 		TerrainQuadTree terrainTree = (TerrainQuadTree) terrain.getQuadTree();
 		VAO vao = terrainTree.getVao();
-		vao.bind(0, 1, 2);
+		vao.bind(0, 1);
 		bindTexture(terrain);
 		shader.loadShineVariables(1, 0);
 		shader.loadWorldMatrix(terrainTree.getWorldMatrix());
@@ -110,13 +110,11 @@ public class TerrainRenderer {
 	}
 
 	private void unbindTexture() {
-		VAO.unbind(0, 1, 2);
+		VAO.unbind(0, 1);
 		Texture2D.unbind();
 	}
 
 	private void loadModelMatrix(ITerrain terrain) {
-//		Matrix4f transformationMatrix = Maths
-//				.createTransformationMatrix(new Vector3f(terrain.getX(), 0, terrain.getZ()), 0, 0, 0, 1);
 		Matrix4f transformationMatrix = Maths
 				.createTransformationMatrix(new Vector3f(EngineSettings.SCALE_XZ, EngineSettings.SCALE_Y, EngineSettings.SCALE_XZ), 0, 0, 0, 1);
 		shader.loadTranformationMatrix(transformationMatrix);

--- a/src/main/java/engine/renderer/terrain/TerrainRenderer.java
+++ b/src/main/java/engine/renderer/terrain/TerrainRenderer.java
@@ -22,11 +22,9 @@ import tool.math.vector.Vector3f;
 public class TerrainRenderer {
 
 	private TerrainShader shader;
-	private Texture2D heightMap;
 	private Texture2D normalMap;
 
 	public TerrainRenderer(Matrix4f projectionMatrix) {
-		this.heightMap = new Texture2D("heightMap", EngineSettings.TEXTURE_HEIGHT_MAP_PATH + "heightMap.png");
 		this.shader = new TerrainShader();
 		shader.start();
 		shader.loadProjectionMatrix(projectionMatrix);
@@ -108,7 +106,7 @@ public class TerrainRenderer {
 		texturePack.getGTexture().bind(2);
 		texturePack.getBTexture().bind(3);
 		terrain.getBlendMap().bind(4);
-		this.heightMap.bind(7);
+		terrain.getHeightMap().bind(7);
 		this.normalMap.bind(8);
 	}
 
@@ -123,10 +121,6 @@ public class TerrainRenderer {
 		Matrix4f transformationMatrix = Maths
 				.createTransformationMatrix(new Vector3f(EngineSettings.SCALE_XZ, EngineSettings.SCALE_Y, EngineSettings.SCALE_XZ), 0, 0, 0, 1);
 		shader.loadTranformationMatrix(transformationMatrix);
-	}
-	
-	public Texture2D getHeightMap() {
-		return this.heightMap;
 	}
 	
 	public void setNormalMap(Texture2D normalMap) {

--- a/src/main/java/engine/shader/ShaderProgram.java
+++ b/src/main/java/engine/shader/ShaderProgram.java
@@ -164,11 +164,11 @@ public abstract class ShaderProgram {
 	protected void addUniform(String name) {		
 		int uniformLocation = this.getUniformLocation(name);
 		
-//		if (uniformLocation == 0xFFFFFFFF) {
-//			System.err.println(this.getClass().getName() + " Error: Could not find uniform: " + name);
-//			new Exception().printStackTrace();
-//			System.exit(1);
-//		}
+		if (uniformLocation == 0xFFFFFFFF) {
+			System.err.println(this.getClass().getName() + " Error: Could not find uniform: " + name);
+			new Exception().printStackTrace();
+			System.exit(1);
+		}
 		
 		this.unfiroms.put(name, uniformLocation);
 	}

--- a/src/main/java/engine/shader/entity/decor/DecorEntityShader.java
+++ b/src/main/java/engine/shader/entity/decor/DecorEntityShader.java
@@ -57,7 +57,6 @@ public class DecorEntityShader extends ShaderProgram {
 	public static final String UNIFORM_SPECULAR_MAP = "specularMap";
 	public static final String UNIFORM_SHADOW_MAP = "shadowMap";		
 	//light		
-	public static final String UNIFORM_LIGHT_COUNT = "lightCount";
 	public static final String UNIFORM_LIGHT_POSITION = "lightPosition";
 	public static final String UNIFORM_LIGHT_COLOR = "lightColor";
 	public static final String UNIFORM_ATTENUATION = "attenuation";
@@ -81,14 +80,15 @@ public class DecorEntityShader extends ShaderProgram {
 	@Override
 	protected void loadUniformLocations() {
 		//matrix
+//		super.addUniform(UNIFORM_CAMERA_POSITION);
 		super.addUniform(UNIFORM_TRANSFORMATION_MATRIX);
 		super.addUniform(UNIFORM_PROJECTION_MATRIX);
 		super.addUniform(UNIFORM_VIEW_MATRIX);
-		super.addUniform(UNIFORM_CAMERA_POSITION);
+
 		//shine variables
 		super.addUniform(UNIFORM_SHINE_DAMPER);
 		super.addUniform(UNIFORM_REFLECTIVITY);
-		super.addUniform(UNIFORM_REFLECTIVE_FACTOR);
+//		super.addUniform(UNIFORM_REFLECTIVE_FACTOR);
 		//boolean
 		super.addUniform(UNIFORM_USES_FAKE_LIGHTING);
 		super.addUniform(UNIFORM_USES_SPECULAR_MAP);
@@ -111,8 +111,7 @@ public class DecorEntityShader extends ShaderProgram {
 		super.addUniform(UNIFORM_DIFFUSE_MAP);
 		super.addUniform(UNIFORM_SPECULAR_MAP);
 		super.addUniform(UNIFORM_SHADOW_MAP);		
-		//light		
-		super.addUniform(UNIFORM_LIGHT_COUNT);		
+		//light			
 		for (int i = 0; i < EngineSettings.MAX_LIGHTS; i++) {
 			super.addUniform(UNIFORM_LIGHT_POSITION + "[" + i + "]");
 			super.addUniform(UNIFORM_LIGHT_COLOR + "[" + i + "]");
@@ -133,7 +132,7 @@ public class DecorEntityShader extends ShaderProgram {
 	public void loadCamera(ICamera camera) {
 		Matrix4f viewMatrix = Maths.createViewMatrix(camera);
 		super.loadMatrix(UNIFORM_VIEW_MATRIX, viewMatrix);
-		super.load3DVector(UNIFORM_CAMERA_POSITION, camera.getPosition());
+//		super.load3DVector(UNIFORM_CAMERA_POSITION, camera.getPosition());
 	}
 
 	public void loadViewMatrix(ICamera camera) {
@@ -190,7 +189,8 @@ public class DecorEntityShader extends ShaderProgram {
 	}
 
 	public void loadReflectiveFactor(float index) {
-		super.loadFloat(UNIFORM_REFLECTIVE_FACTOR, index);
+		// TODO
+//		super.loadFloat(UNIFORM_REFLECTIVE_FACTOR, index);
 	}
 
 	public void loadFogDensity(float density) {
@@ -198,7 +198,6 @@ public class DecorEntityShader extends ShaderProgram {
 	}
 
 	public void loadLights(Collection<ILight> lights) {
-		super.loadInt(UNIFORM_LIGHT_COUNT, EngineSettings.MAX_LIGHTS);
 		Iterator<ILight> iterator = lights.iterator();
 		for (int i = 0; i < EngineSettings.MAX_LIGHTS; i++) {
 			if (iterator.hasNext()) {

--- a/src/main/java/engine/shader/entity/decor/decorEntity_F_shader.glsl
+++ b/src/main/java/engine/shader/entity/decor/decorEntity_F_shader.glsl
@@ -1,12 +1,13 @@
 //FRAGMENT SHADER - Entity
 #version 400 core
+#define LIGHT_MAX 10
 
 /*===== in ======*/
 
 //geometry
 in vec2 pass_textureCoordinates;
 in vec3 surfaceNormal;
-in vec3 toLightVector[10];
+in vec3 toLightVector[LIGHT_MAX];
 in vec3 toCameraVector;
 in vec4 shadowCoords;
 
@@ -28,9 +29,8 @@ uniform float shadowMapSize;
 uniform int shadowPCFCount;
 
 //light and colour
-uniform vec3 lightColor[10];
-uniform vec3 attenuation[10];
-uniform int lightCount;
+uniform vec3 lightColor[LIGHT_MAX];
+uniform vec3 attenuation[LIGHT_MAX];
 uniform float shineDamper;
 uniform float reflectivity;
 uniform vec3 skyColor;
@@ -51,7 +51,7 @@ void main(void) {
 	float texelSize = 1.0 / shadowMapSize;
     float total = 0.0;
 
-    for(int x=-shadowPCFCount; x<=shadowPCFCount; x++) {
+    for(int x = -shadowPCFCount; x <= shadowPCFCount; x++) {
    		 for(int y=-shadowPCFCount; y<=shadowPCFCount; y++) {
    				 float objectNearestLight = texture(shadowMap, shadowCoords.xy + vec2(x, y) * texelSize).r;
    			 	 if(shadowCoords.z > objectNearestLight + 0.001) {
@@ -70,7 +70,7 @@ void main(void) {
     vec3 totalDiffuse = vec3(0.0);
     vec3 totalSpecular = vec3(0.0);
 
-	for(int i=0;i<lightCount;i++) {
+	for(int i = 0; i < LIGHT_MAX; i++) {
 		float distance = length(toLightVector[i]);
 		float attFactor = attenuation[1].x + (attenuation[i].y * distance) + (attenuation[i].z * distance * distance);
 		vec3 unitLightVector = normalize(toLightVector[i]);

--- a/src/main/java/engine/shader/entity/decor/decorEntity_V_shader.glsl
+++ b/src/main/java/engine/shader/entity/decor/decorEntity_V_shader.glsl
@@ -1,5 +1,6 @@
 //VERTEX SHADER - Entity
 #version 400 core
+#define LIGHT_MAX 10
 
 /*===== in ======*/
 in vec3 position;
@@ -10,7 +11,7 @@ in vec3 normal;
 out vec2 pass_textureCoordinates;
 out vec3 pass_normal;
 out vec3 surfaceNormal;
-out vec3 toLightVector[10];
+out vec3 toLightVector[LIGHT_MAX];
 out vec3 toCameraVector;
 out float fogVisibility;
 out vec4 shadowCoords;
@@ -19,12 +20,11 @@ out vec4 shadowCoords;
 uniform mat4 transformationMatrix;
 uniform mat4 projectionMatrix;
 uniform mat4 viewMatrix;
-uniform vec3 cameraPosition;
 uniform vec4 clipPlane;
+uniform vec3 cameraPosition;
 
 //light
-uniform vec3 lightPosition[10];
-uniform int lightCount;
+uniform vec3 lightPosition[LIGHT_MAX];
 uniform float usesFakeLighting;
 
 //shadows
@@ -49,7 +49,7 @@ void main(void) {
    shadowCoords = toShadowMapSpace * worldPosition;
    
    gl_ClipDistance[0] = dot(worldPosition, clipPlane);
-   
+
    vec4 positionRelativeToCam = viewMatrix * worldPosition;
    gl_Position = projectionMatrix * positionRelativeToCam;
       
@@ -61,11 +61,11 @@ void main(void) {
    
    vec3 actualNormal = normal;
    if(usesFakeLighting > 0.5) {
-      actualNormal = vec3(0.0,1.0,0.0);
+      actualNormal = vec3(0.0, 1.0, 0.0);
    }
 
-   surfaceNormal = (transformationMatrix * vec4(actualNormal,0.0)).xyz;
-   for(int i=0; i<lightCount; i++) {
+   surfaceNormal = (transformationMatrix * vec4(actualNormal, 0.0)).xyz;
+   for(int i=0; i < LIGHT_MAX; i++) {
       toLightVector[i] = lightPosition[i] - worldPosition.xyz; 
    }
    
@@ -79,5 +79,5 @@ void main(void) {
    distance = distance - (shadowDistance - shadowTransitionDistance);
    distance = distance / shadowTransitionDistance;
    shadowCoords.w = clamp(1.0 - distance, 0.0, 1.0);
-   
+
 }

--- a/src/main/java/engine/shader/entity/textured/TexturedEntityShader.java
+++ b/src/main/java/engine/shader/entity/textured/TexturedEntityShader.java
@@ -40,7 +40,7 @@ public class TexturedEntityShader extends ShaderProgram {
 	//boolean
 	public static final String UNIFORM_USES_FAKE_LIGHTING = "usesFakeLighting";
 	public static final String UNIFORM_USES_SPECULAR_MAP = "usesSpecularMap";
-	public static final String UNIFORM_USES_ALPHA_MAP = "usesAlpaMap";
+	public static final String UNIFORM_USES_ALPHA_MAP = "usesAlphaMap";
 	public static final String UNIFORM_IS_CHOSEN = "isChosen";
 	//shine variables
 	public static final String UNIFORM_SHINE_DAMPER = "shineDamper";

--- a/src/main/java/engine/shader/gpgpu/HeightMapShader.java
+++ b/src/main/java/engine/shader/gpgpu/HeightMapShader.java
@@ -7,8 +7,6 @@ public class HeightMapShader extends ShaderProgram {
 	
 	//----shaders
 	private static final String COMPUTE_SHADER = EngineSettings.SHADERS_GPGPU_PATH + "heightMap_C_shader.glsl";
-	//----attributes
-	private static final String ATTRIBUTE_POSITION = "position";
 	//----uniforms
 	private static final String UNIFORM_SIZE = "size";
 	
@@ -24,9 +22,7 @@ public class HeightMapShader extends ShaderProgram {
 	}
 
 	@Override
-	protected void bindAttributes() {
-		bindAttribute(0, ATTRIBUTE_POSITION);
-	}
+	protected void bindAttributes() {}
 	
 	public void loadMapSize(int size) {
 		loadInt(UNIFORM_SIZE, size);

--- a/src/main/java/engine/shader/gpgpu/HeightMapShader.java
+++ b/src/main/java/engine/shader/gpgpu/HeightMapShader.java
@@ -1,11 +1,12 @@
 package shader.gpgpu;
 
+import core.settings.EngineSettings;
 import shader.ShaderProgram;
 
 public class HeightMapShader extends ShaderProgram {
 	
 	//----shaders
-	private static final String COMPUTE_SHADER = "heighMap_C_shader.glsl";
+	private static final String COMPUTE_SHADER = EngineSettings.SHADERS_GPGPU_PATH + "heightMap_C_shader.glsl";
 	//----attributes
 	private static final String ATTRIBUTE_POSITION = "position";
 	//----uniforms

--- a/src/main/java/engine/shader/gpgpu/HeightMapShader.java
+++ b/src/main/java/engine/shader/gpgpu/HeightMapShader.java
@@ -7,10 +7,9 @@ public class HeightMapShader extends ShaderProgram {
 	
 	//----shaders
 	private static final String COMPUTE_SHADER = EngineSettings.SHADERS_GPGPU_PATH + "heightMap_C_shader.glsl";
-	//----attributes
-	private static final String ATTRIBUTE_POSITION = "position";
 	//----uniforms
 	private static final String UNIFORM_SIZE = "size";
+	public static final String UNIFORM_POSITION_MAP = "positionMap";
 	
 	public HeightMapShader() {
 		super();
@@ -24,12 +23,14 @@ public class HeightMapShader extends ShaderProgram {
 	}
 
 	@Override
-	protected void bindAttributes() {
-		bindAttribute(0, ATTRIBUTE_POSITION);
-	}
+	protected void bindAttributes() {}
 	
 	public void loadMapSize(int size) {
 		loadInt(UNIFORM_SIZE, size);
 	}
+	
+	public void connectTextureUnits() {
+		super.loadInt(UNIFORM_POSITION_MAP, 1);
+	}	
 
 }

--- a/src/main/java/engine/shader/gpgpu/NormalMapShader.java
+++ b/src/main/java/engine/shader/gpgpu/NormalMapShader.java
@@ -8,8 +8,11 @@ public class NormalMapShader extends ShaderProgram {
 	//---shaders
 	private static final String COMPUTE_FILE = EngineSettings.SHADERS_GPGPU_PATH + "normalMap_C_shader.glsl";
 	//---uniforms
+	// parameters
 	private static final String UNIFORM_N = "N";
 	private static final String UNIFORM_STRENGTH = "strength";
+	// materials
+	private static final String UNIFORM_HEIGHT_MAP = "heightMap";
 	
 	public NormalMapShader() {
 		super();
@@ -21,10 +24,15 @@ public class NormalMapShader extends ShaderProgram {
 	protected void loadUniformLocations() {
 		addUniform(UNIFORM_N);
 		addUniform(UNIFORM_STRENGTH);
+		addUniform(UNIFORM_HEIGHT_MAP);
 	}
 
 	@Override
 	protected void bindAttributes() {}
+	
+	public void connectTextureUnits() {
+		super.loadInt(UNIFORM_HEIGHT_MAP, 0);
+	}
 	
 	public void updateUniforms(int n, float strength) {
 		super.loadInt(UNIFORM_N, n);

--- a/src/main/java/engine/shader/gpgpu/heightMap_C_shader.glsl
+++ b/src/main/java/engine/shader/gpgpu/heightMap_C_shader.glsl
@@ -1,10 +1,9 @@
 //COMPUTE SHADER - heightMap
 #version 430 core
 
-#define VERTEX_COUNT 128
+#define VERTEX_COUNT 512
 
-layout (local_size_x = VERTEX_COUNT, local_size_y = VERTEX_COUNT, local_size_z = VERTEX_COUNT) in;
-layout (std140, binding = 0) uniform vec3 position[VERTEX_COUNT];
+layout(std430, binding = 0) buffer position;
 
 layout (binding = 0, rgba32f) uniform writeonly image2D heightMap;
 
@@ -14,12 +13,12 @@ void main(void) {
 
 	ivec2 x = ivec2(gl_GlobalInvocationID.xy);
 
-	vec4 pos = imageLoad()
+	vec4 pos = vec4(position, 1.0);
 	vec2 texCoord = gl_GlobalInvocationID.xy / float(size);
 
 	float texelSize = 1.0 / size;
 
-	vec4 Color.a = position
+	vec4 Color.r = position.z;
 
 	imageStore(heightMap, x, Color);
 

--- a/src/main/java/engine/shader/gpgpu/heightMap_C_shader.glsl
+++ b/src/main/java/engine/shader/gpgpu/heightMap_C_shader.glsl
@@ -15,9 +15,9 @@ void main(void) {
 
 	ivec2 xy = ivec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y);
 
-	int offset = int(gl_WorkGroupID.y * 512 + gl_WorkGroupID.x);
+	int offset = int(gl_WorkGroupID.y * size + gl_WorkGroupID.x);
 
-	float height = texelFetchBuffer(positionMap, offset).y / 256;
+	float height = texelFetchBuffer(positionMap, offset).y;
 
 	vec4 TextureColor = vec4(height, height, height, 1.0);
 

--- a/src/main/java/engine/shader/gpgpu/heightMap_C_shader.glsl
+++ b/src/main/java/engine/shader/gpgpu/heightMap_C_shader.glsl
@@ -1,25 +1,28 @@
 //COMPUTE SHADER - heightMap
 #version 430 core
+#define TERRAIN_SIZE 128
+#extension GL_EXT_gpu_shader4 : enable
 
-#define VERTEX_COUNT 512
-
-layout(std430, binding = 0) buffer position;
+layout (local_size_x = 16, local_size_y = 16) in;
 
 layout (binding = 0, rgba32f) uniform writeonly image2D heightMap;
 
+uniform samplerBuffer positionMap;
 uniform int size;
+uniform float scale;
 
 void main(void) {
 
-	ivec2 x = ivec2(gl_GlobalInvocationID.xy);
+	ivec2 xy = ivec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y);
 
-	vec4 pos = vec4(position, 1.0);
-	vec2 texCoord = gl_GlobalInvocationID.xy / float(size);
 
-	float texelSize = 1.0 / size;
 
-	vec4 Color.r = position.z;
+	int offset = int(gl_WorkGroupID.y * gl_NumWorkGroups.x + gl_WorkGroupID.x);
 
-	imageStore(heightMap, x, Color);
+	float height = texelFetchBuffer(positionMap, offset).y;
+
+	vec4 TextureColor = vec4(height, height, height, 1.0);
+
+	imageStore(heightMap, xy, TextureColor);
 
 }

--- a/src/main/java/engine/shader/gpgpu/heightMap_C_shader.glsl
+++ b/src/main/java/engine/shader/gpgpu/heightMap_C_shader.glsl
@@ -1,25 +1,26 @@
 //COMPUTE SHADER - heightMap
 #version 430 core
+#define TERRAIN_SIZE 128
+#extension GL_EXT_gpu_shader4 : enable
 
-#define VERTEX_COUNT 512
-
-layout(std430, binding = 0) buffer position;
+layout (local_size_x = 1, local_size_y = 1) in;
 
 layout (binding = 0, rgba32f) uniform writeonly image2D heightMap;
 
+uniform samplerBuffer positionMap;
 uniform int size;
+uniform float scale;
 
 void main(void) {
 
-	ivec2 x = ivec2(gl_GlobalInvocationID.xy);
+	ivec2 xy = ivec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y);
 
-	vec4 pos = vec4(position, 1.0);
-	vec2 texCoord = gl_GlobalInvocationID.xy / float(size);
+	int offset = int(gl_WorkGroupID.y * 512 + gl_WorkGroupID.x);
 
-	float texelSize = 1.0 / size;
+	float height = texelFetchBuffer(positionMap, offset).y / 256;
 
-	vec4 Color.r = position.z;
+	vec4 TextureColor = vec4(height, height, height, 1.0);
 
-	imageStore(heightMap, x, Color);
+	imageStore(heightMap, xy, TextureColor);
 
 }

--- a/src/main/java/engine/shader/gpgpu/normalMap_C_shader.glsl
+++ b/src/main/java/engine/shader/gpgpu/normalMap_C_shader.glsl
@@ -11,7 +11,7 @@ uniform float strength;
 
 void main(void) {
 
-	ivec2 x = ivec2(gl_GlobalInvocationID.xy);
+	ivec2 xy = ivec2(gl_GlobalInvocationID.xy);
 	vec2 texCoord = gl_GlobalInvocationID.xy / float(N);
 
 	float texelSize = 1.0 / N;
@@ -32,7 +32,7 @@ void main(void) {
 	normal.x = z0 + 2 * z3 + z5 - z2 - 2 * z4 - z7;
 	normal.y = z0 + 2 * z1 + z2 - z5 - 2 * z6 - z7;
 
-	imageStore(normalMap, x, vec4((normalize(normal) + 1/2.0, 1)));
+	imageStore(normalMap, xy, vec4(normalize(normal) + 1/2.0, 1));
 
 
 }

--- a/src/main/java/engine/shader/terrain/TerrainShader.java
+++ b/src/main/java/engine/shader/terrain/TerrainShader.java
@@ -91,7 +91,6 @@ public class TerrainShader extends ShaderProgram {
 		this.bindFragOutput(1, ATTRIBUTE_OUT_BRIGHT_COLOR);
 		this.bindAttribute(0, ATTRIBUTE_POSITION);
 		this.bindAttribute(1, ATTRIBUTE_TEXTURE_COORDINATES);
-		this.bindAttribute(2, ATTRIBUTE_NORMAL);
 	}
 
 	@Override

--- a/src/main/java/engine/shader/terrain/TerrainShader.java
+++ b/src/main/java/engine/shader/terrain/TerrainShader.java
@@ -25,10 +25,8 @@ public class TerrainShader extends ShaderProgram {
 	private static final String ATTRIBUTE_OUT_COLOR = "out_Color";
 	private static final String ATTRIBUTE_OUT_BRIGHT_COLOR = "out_BrightColor";
 	private static final String ATTRIBUTE_POSITION = "in_position";
-	private static final String ATTRIBUTE_TEXTURE_COORDINATES = "textureCoordinates";
 	//----uniforms
 	//matrix
-	private static final String UNIFORM_TRANSFORMATION_MATRIX = "transformationMatrix";
 	private static final String UNIFORM_PROJECTION_MATRIX = "projectionMatrix";
 	private static final String UNIFORM_VIEW_MATRIX = "viewMatrix";	
 	private static final String UNIFORM_LOCAL_MATRIX = "localMatrix";
@@ -89,13 +87,11 @@ public class TerrainShader extends ShaderProgram {
 		this.bindFragOutput(0, ATTRIBUTE_OUT_COLOR);
 		this.bindFragOutput(1, ATTRIBUTE_OUT_BRIGHT_COLOR);
 		this.bindAttribute(0, ATTRIBUTE_POSITION);
-		this.bindAttribute(1, ATTRIBUTE_TEXTURE_COORDINATES);
 	}
 
 	@Override
 	protected void loadUniformLocations() {
 		//matrix
-		this.addUniform(UNIFORM_TRANSFORMATION_MATRIX);
 		this.addUniform(UNIFORM_PROJECTION_MATRIX);
 		this.addUniform(UNIFORM_VIEW_MATRIX);
 		this.addUniform(UNIFORM_LOCAL_MATRIX);
@@ -137,7 +133,6 @@ public class TerrainShader extends ShaderProgram {
 		this.addUniform(UNIFORM_SHADOW_TRANSITION_DISTANCE);
 		this.addUniform(UNIFORM_SHADOW_PCF_COUNT);
 		//light
-		this.addUniform(UNIFORM_LIGHT_COUNT);
 		for (int i = 0; i < EngineSettings.MAX_LIGHTS; i++) {
 			this.addUniform(UNIFORM_LIGHT_POSITION + "[" + i + "]");
 			this.addUniform(UNIFORM_LIGHT_COLOR + "[" + i + "]");
@@ -162,10 +157,6 @@ public class TerrainShader extends ShaderProgram {
 
 	public void loadViewMatrix(Matrix4f viewMatrix) {
 		this.loadMatrix(UNIFORM_VIEW_MATRIX, viewMatrix);
-	}
-
-	public void loadTranformationMatrix(Matrix4f matrix) {
-		this.loadMatrix(UNIFORM_TRANSFORMATION_MATRIX, matrix);
 	}
 	
 	public void loadWorldMatrix(Matrix4f worldMatrix) {
@@ -232,7 +223,6 @@ public class TerrainShader extends ShaderProgram {
 	}
 
 	public void loadLights(Collection<ILight> lights) {
-		this.loadInt(UNIFORM_LIGHT_COUNT, EngineSettings.MAX_LIGHTS);
 		Iterator<ILight> iterator = lights.iterator();
 		for (int i = 0; i < EngineSettings.MAX_LIGHTS; i++) {
 			if (iterator.hasNext()) {

--- a/src/main/java/engine/shader/terrain/TerrainShader.java
+++ b/src/main/java/engine/shader/terrain/TerrainShader.java
@@ -26,7 +26,6 @@ public class TerrainShader extends ShaderProgram {
 	private static final String ATTRIBUTE_OUT_BRIGHT_COLOR = "out_BrightColor";
 	private static final String ATTRIBUTE_POSITION = "in_position";
 	private static final String ATTRIBUTE_TEXTURE_COORDINATES = "textureCoordinates";
-	private static final String ATTRIBUTE_NORMAL = "normal";
 	//----uniforms
 	//matrix
 	private static final String UNIFORM_TRANSFORMATION_MATRIX = "transformationMatrix";

--- a/src/main/java/engine/shader/terrain/terrain_F_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_F_shader.glsl
@@ -1,7 +1,7 @@
 //FRAGMENT SHADER - Terrain
 #version 430 core
 
-#define LIGHT_MAX 10 //max light source count
+#define LIGHT_MAX 10 // max light source count
 
 /*===== in ======*/
 in vec2 fs_textureCoords;

--- a/src/main/java/engine/shader/terrain/terrain_F_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_F_shader.glsl
@@ -1,11 +1,10 @@
 //FRAGMENT SHADER - Terrain
 #version 430 core
 
-#define LIGHT_MAX 10 //max light source count
+#define LIGHT_MAX 10 // max light source count
 
 /*===== in ======*/
 in vec2 fs_textureCoords;
-in vec3 fs_surfaceNormal;
 in vec3 fs_toLightVector[LIGHT_MAX];
 in vec3 fs_toCameraVector;
 in float fs_visibility;
@@ -68,8 +67,9 @@ void main(void) {
    vec4 bTextureColour = texture(bTexture,tiledCoords) * blendMapColour.b;
 
    vec4 totalColour = backgroundTextureColour + rTextureColour + gTextureColour + bTextureColour;
+   vec3 normal = texture(normalMap, fs_textureCoords).rgb;
 
-   vec3 unitNormal = normalize(fs_surfaceNormal);
+   vec3 unitNormal = normalize(normal);
    vec3 unitVectorToCamera = normalize(fs_toCameraVector);
    
    vec3 totalDiffuse = vec3(0.0);

--- a/src/main/java/engine/shader/terrain/terrain_F_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_F_shader.glsl
@@ -4,8 +4,6 @@
 #define LIGHT_MAX 10 // max light source count
 
 /*===== in ======*/
-in vec3 fs_normal;
-in vec3 fs_tangent;
 in vec2 fs_textureCoords;
 in vec3 fs_toLightVector[LIGHT_MAX];
 in vec3 fs_toCameraVector;
@@ -70,17 +68,7 @@ void main(void) {
 
    vec4 totalColour = backgroundTextureColour + rTextureColour + gTextureColour + bTextureColour;
 
-   // normal vector calculations
-   vec3 normal_TS = normalize(2.0 * texture(normalMap, fs_textureCoords).rgb - vec3(1.0));
-   vec3 bitangent = cross(normal_TS, fs_tangent);
-
-   mat3 normalMatrix = mat3(
-		   	   fs_tangent.x, bitangent.x, normal_TS.x,
-			   fs_tangent.y, bitangent.y, normal_TS.y,
-			   fs_tangent.z, bitangent.z, normal_TS.z
-		   );
-
-   vec3 unitNormal = normalize(normalMatrix * fs_normal);
+   vec3 unitNormal =  normalize(2.0 * texture(normalMap, fs_textureCoords).rgb + vec3(1.0));
    vec3 unitVectorToCamera = normalize(fs_toCameraVector);
    
    vec3 totalDiffuse = vec3(0.0);

--- a/src/main/java/engine/shader/terrain/terrain_F_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_F_shader.glsl
@@ -4,6 +4,8 @@
 #define LIGHT_MAX 10 // max light source count
 
 /*===== in ======*/
+in vec3 fs_normal;
+in vec3 fs_tangent;
 in vec2 fs_textureCoords;
 in vec3 fs_toLightVector[LIGHT_MAX];
 in vec3 fs_toCameraVector;
@@ -67,9 +69,18 @@ void main(void) {
    vec4 bTextureColour = texture(bTexture,tiledCoords) * blendMapColour.b;
 
    vec4 totalColour = backgroundTextureColour + rTextureColour + gTextureColour + bTextureColour;
-   vec3 normal = texture(normalMap, fs_textureCoords).rgb;
 
-   vec3 unitNormal = normalize(normal);
+   // normal vector calculations
+   vec3 normal_TS = normalize(2.0 * texture(normalMap, fs_textureCoords).rgb - vec3(1.0));
+   vec3 bitangent = cross(normal_TS, fs_tangent);
+
+   mat3 normalMatrix = mat3(
+		   	   fs_tangent.x, bitangent.x, normal_TS.x,
+			   fs_tangent.y, bitangent.y, normal_TS.y,
+			   fs_tangent.z, bitangent.z, normal_TS.z
+		   );
+
+   vec3 unitNormal = normalize(normalMatrix * fs_normal);
    vec3 unitVectorToCamera = normalize(fs_toCameraVector);
    
    vec3 totalDiffuse = vec3(0.0);

--- a/src/main/java/engine/shader/terrain/terrain_G_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_G_shader.glsl
@@ -1,46 +1,50 @@
 //GEOMETRY SHADER - Terrain
 #version 430
 
-#define LIGHT_MAX 10 //max light source count
+#define LIGHT_MAX 10 // max light source count
 
 layout(triangles) in;
 layout(triangle_strip, max_vertices = 3) out;
 
+/*===== in ======*/
 in vec2 gs_textureCoords[];
-in vec3 gs_surfaceNormal[];
 in vec3 gs_toLightVector[][LIGHT_MAX];
 in vec3 gs_toCameraVector[];
 in float gs_visibility[];
 in vec4 gs_shadowCoords[];
+in float gs_clipDistance[];
 
+/*===== out =====*/
 out vec2 fs_textureCoords;
-out vec3 fs_surfaceNormal;
 out vec3 fs_toLightVector[LIGHT_MAX];
 out vec3 fs_toCameraVector;
 out float fs_visibility;
 out vec4 fs_shadowCoords;
 
+/*== uniforms ===*/
 uniform mat4 projectionMatrix;
 uniform mat4 viewMatrix;
 uniform mat4 localMatrix;
 uniform mat4 worldMatrix;
 
+/*-------- functions -----------*/
 void createVertex(int index, mat4 projectionViewMatrix) {
 
 	fs_textureCoords = gs_textureCoords[index];
-	fs_surfaceNormal = (projectionViewMatrix * vec4(gs_surfaceNormal[index],1.0)).xyz;
 	for(int i = 0; i < LIGHT_MAX; i++) {
-		fs_toLightVector[i] = (projectionViewMatrix * vec4(gs_toLightVector[index][i], 1.0)).xyz;
+		fs_toLightVector[i] = gs_toLightVector[index][i];
 	}
 	fs_toCameraVector = gs_toCameraVector[index];
 	fs_visibility = gs_visibility[index];
 	fs_shadowCoords = gs_shadowCoords[index];
+//	gl_ClipDistance[0] = gs_clipDistance[index];
 
 	gl_Position = projectionViewMatrix * gl_in[index].gl_Position;
 
 	EmitVertex();
 }
 
+/*------------- main ---------------*/
 void main() {
 
 	mat4 projectionViewMatrix = projectionMatrix * viewMatrix;

--- a/src/main/java/engine/shader/terrain/terrain_G_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_G_shader.glsl
@@ -8,14 +8,10 @@ layout(triangle_strip, max_vertices = 3) out;
 
 /*===== in ======*/
 in vec2 gs_textureCoords[];
-in vec3 gs_toLightVector[][LIGHT_MAX];
-in vec3 gs_toCameraVector[];
 in float gs_visibility[];
 in vec4 gs_shadowCoords[];
-in float gs_clipDistance[];
 
 /*===== out =====*/
-out vec3 fs_normal;
 out vec3 fs_tangent;
 out vec2 fs_textureCoords;
 out vec3 fs_toLightVector[LIGHT_MAX];
@@ -29,29 +25,28 @@ uniform mat4 projectionMatrix;
 uniform mat4 viewMatrix;
 uniform mat4 localMatrix;
 uniform mat4 worldMatrix;
+uniform vec4 clipPlane;
+
+uniform vec3 lightPosition[LIGHT_MAX];
 
 /*-------- functions -----------*/
-vec4 createVertex(int index, mat4 projectionViewMatrix) {
+void createVertex(int index, mat4 projectionViewMatrix) {
 
 	fs_textureCoords = gs_textureCoords[index];
-	for(int i = 0; i < LIGHT_MAX; i++) {
-		fs_toLightVector[i] = gs_toLightVector[index][i];
-	}
-	fs_toCameraVector = gs_toCameraVector[index];
 	fs_visibility = gs_visibility[index];
 	fs_shadowCoords = gs_shadowCoords[index];
 
-//	gl_ClipDistance[0] = gs_clipDistance[index];
-
-	fs_normal = (projectionViewMatrix * vec4(0, 1, 0, 1)).xyz;
+	gl_ClipDistance[0] = dot(gl_in[index].gl_Position, clipPlane);
 
 	vec4 position = gl_in[index].gl_Position;
+	for(int i = 0; i < LIGHT_MAX; i++) {
+		fs_toLightVector[i] = lightPosition[i] - (projectionMatrix * position).xyz;
+	}
+	fs_toCameraVector = (inverse(viewMatrix) * vec4(0.0,0.0,0.0,1.0)).xyz - (projectionMatrix * position).xyz;
 
 	gl_Position = projectionViewMatrix * position;
 
 	EmitVertex();
-
-	return position;
 }
 
 /*------------- main ---------------*/
@@ -59,23 +54,10 @@ void main() {
 
 	mat4 projectionViewMatrix = projectionMatrix * viewMatrix;
 
-	vec3[3] position;
-
 	// pass values
 	for(int i=0; i < gl_in.length(); i++) {
-		position[i] = createVertex(i, projectionViewMatrix).xyz;
+		createVertex(i, projectionViewMatrix);
 	}
-
-	// calculate tangent vector
-	vec3 deltaPos1 = position[1] - position[0];
-	vec3 deltaPos2 = position[2] - position[0];
-
-	vec2 deltaUVec1 = gs_textureCoords[1] - gs_textureCoords[0];
-	vec2 deltaUVec2 = gs_textureCoords[2] - gs_textureCoords[0];
-	float scale = 1.0 / (deltaUVec1.x * deltaUVec2.y - deltaUVec1.y * deltaUVec2.x);
-	deltaPos1 = deltaPos1 * deltaUVec2.y;
-	deltaPos2 = deltaPos2 * deltaUVec1.y;
-	fs_tangent = scale * (deltaPos1 - deltaPos2);
 
 	EndPrimitive();
 

--- a/src/main/java/engine/shader/terrain/terrain_G_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_G_shader.glsl
@@ -15,11 +15,14 @@ in vec4 gs_shadowCoords[];
 in float gs_clipDistance[];
 
 /*===== out =====*/
+out vec3 fs_normal;
+out vec3 fs_tangent;
 out vec2 fs_textureCoords;
 out vec3 fs_toLightVector[LIGHT_MAX];
 out vec3 fs_toCameraVector;
 out float fs_visibility;
 out vec4 fs_shadowCoords;
+
 
 /*== uniforms ===*/
 uniform mat4 projectionMatrix;
@@ -28,7 +31,7 @@ uniform mat4 localMatrix;
 uniform mat4 worldMatrix;
 
 /*-------- functions -----------*/
-void createVertex(int index, mat4 projectionViewMatrix) {
+vec4 createVertex(int index, mat4 projectionViewMatrix) {
 
 	fs_textureCoords = gs_textureCoords[index];
 	for(int i = 0; i < LIGHT_MAX; i++) {
@@ -37,11 +40,18 @@ void createVertex(int index, mat4 projectionViewMatrix) {
 	fs_toCameraVector = gs_toCameraVector[index];
 	fs_visibility = gs_visibility[index];
 	fs_shadowCoords = gs_shadowCoords[index];
+
 //	gl_ClipDistance[0] = gs_clipDistance[index];
 
-	gl_Position = projectionViewMatrix * gl_in[index].gl_Position;
+	fs_normal = (projectionViewMatrix * vec4(0, 1, 0, 1)).xyz;
+
+	vec4 position = gl_in[index].gl_Position;
+
+	gl_Position = projectionViewMatrix * position;
 
 	EmitVertex();
+
+	return position;
 }
 
 /*------------- main ---------------*/
@@ -49,9 +59,23 @@ void main() {
 
 	mat4 projectionViewMatrix = projectionMatrix * viewMatrix;
 
+	vec3[3] position;
+
+	// pass values
 	for(int i=0; i < gl_in.length(); i++) {
-		createVertex(i, projectionViewMatrix);
+		position[i] = createVertex(i, projectionViewMatrix).xyz;
 	}
+
+	// calculate tangent vector
+	vec3 deltaPos1 = position[1] - position[0];
+	vec3 deltaPos2 = position[2] - position[0];
+
+	vec2 deltaUVec1 = gs_textureCoords[1] - gs_textureCoords[0];
+	vec2 deltaUVec2 = gs_textureCoords[2] - gs_textureCoords[0];
+	float scale = 1.0 / (deltaUVec1.x * deltaUVec2.y - deltaUVec1.y * deltaUVec2.x);
+	deltaPos1 = deltaPos1 * deltaUVec2.y;
+	deltaPos2 = deltaPos2 * deltaUVec1.y;
+	fs_tangent = scale * (deltaPos1 - deltaPos2);
 
 	EndPrimitive();
 

--- a/src/main/java/engine/shader/terrain/terrain_G_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_G_shader.glsl
@@ -1,18 +1,21 @@
 //GEOMETRY SHADER - Terrain
 #version 430
 
-#define LIGHT_MAX 10 //max light source count
+#define LIGHT_MAX 10 // max light source count
 
 layout(triangles) in;
 layout(triangle_strip, max_vertices = 3) out;
 
+/*===== in ======*/
 in vec2 gs_textureCoords[];
 in vec3 gs_surfaceNormal[];
 in vec3 gs_toLightVector[][LIGHT_MAX];
 in vec3 gs_toCameraVector[];
 in float gs_visibility[];
 in vec4 gs_shadowCoords[];
+in float gs_clipDistance[];
 
+/*===== out =====*/
 out vec2 fs_textureCoords;
 out vec3 fs_surfaceNormal;
 out vec3 fs_toLightVector[LIGHT_MAX];
@@ -20,27 +23,31 @@ out vec3 fs_toCameraVector;
 out float fs_visibility;
 out vec4 fs_shadowCoords;
 
+/*== uniforms ===*/
 uniform mat4 projectionMatrix;
 uniform mat4 viewMatrix;
 uniform mat4 localMatrix;
 uniform mat4 worldMatrix;
 
+/*-------- functions -----------*/
 void createVertex(int index, mat4 projectionViewMatrix) {
 
 	fs_textureCoords = gs_textureCoords[index];
-	fs_surfaceNormal = (projectionViewMatrix * vec4(gs_surfaceNormal[index],1.0)).xyz;
+	fs_surfaceNormal = (projectionViewMatrix * vec4(gs_surfaceNormal[index], 1.0)).xyz;
 	for(int i = 0; i < LIGHT_MAX; i++) {
 		fs_toLightVector[i] = (projectionViewMatrix * vec4(gs_toLightVector[index][i], 1.0)).xyz;
 	}
 	fs_toCameraVector = gs_toCameraVector[index];
 	fs_visibility = gs_visibility[index];
 	fs_shadowCoords = gs_shadowCoords[index];
+	gl_ClipDistance[0] = gs_clipDistance[index];
 
 	gl_Position = projectionViewMatrix * gl_in[index].gl_Position;
 
 	EmitVertex();
 }
 
+/*------------- main ---------------*/
 void main() {
 
 	mat4 projectionViewMatrix = projectionMatrix * viewMatrix;

--- a/src/main/java/engine/shader/terrain/terrain_TC_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_TC_shader.glsl
@@ -5,19 +5,13 @@ layout (vertices = 16) out;
 
 /*===== in ======*/
 in vec2 tc_textureCoords[];
-in vec3 tc_toLightVector[];
-in vec3 tc_toCameraVector[];
 in float tc_visibility[];
 in vec4 tc_shadowCoords[];
-in float tc_clipDistance[];
 
 /*===== out =====*/
 out vec2 te_textureCoords[];
-out vec3 te_toLightVector[];
-out vec3 te_toCameraVector[];
 out float te_visibility[];
 out vec4 te_shadowCoords[];
-out float te_clipDistance[];
 
 /*== constants =*/
 const int AB = 2;
@@ -43,10 +37,10 @@ float LodFactor(float dist) {
 void main() {
 	if(gl_InvocationID == 0) {
 
-		vec3 abMid = vec3(gl_in[0].gl_Position + gl_in[3].gl_Position)/2.0;
-		vec3 bcMid = vec3(gl_in[3].gl_Position + gl_in[15].gl_Position)/2.0;
-		vec3 cdMid = vec3(gl_in[15].gl_Position + gl_in[12].gl_Position)/2.0;
-		vec3 daMid = vec3(gl_in[12].gl_Position + gl_in[0].gl_Position)/2.0;
+		vec3 abMid = vec3(gl_in[0].gl_Position + gl_in[3].gl_Position) / 2.0;
+		vec3 bcMid = vec3(gl_in[3].gl_Position + gl_in[15].gl_Position) / 2.0;
+		vec3 cdMid = vec3(gl_in[15].gl_Position + gl_in[12].gl_Position) / 2.0;
+		vec3 daMid = vec3(gl_in[12].gl_Position + gl_in[0].gl_Position) / 2.0;
 
 		float distanceAB = distance(abMid, cameraPosition);
 		float distanceBC = distance(bcMid, cameraPosition);
@@ -64,12 +58,9 @@ void main() {
 	}
 
 	// simply pass parameters
-	te_toLightVector[gl_InvocationID] = tc_toLightVector[gl_InvocationID];
-	te_toCameraVector[gl_InvocationID] = tc_toCameraVector[gl_InvocationID];
 	te_textureCoords[gl_InvocationID] = tc_textureCoords[gl_InvocationID];
 	te_visibility[gl_InvocationID] = tc_visibility[gl_InvocationID];
 	te_shadowCoords[gl_InvocationID] = tc_shadowCoords[gl_InvocationID];
-	te_clipDistance[gl_InvocationID] = tc_clipDistance[gl_InvocationID];
 
 	gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
 }

--- a/src/main/java/engine/shader/terrain/terrain_TC_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_TC_shader.glsl
@@ -3,30 +3,37 @@
 
 layout (vertices = 16) out;
 
+/*===== in ======*/
 in vec2 tc_textureCoords[];
 in vec3 tc_surfaceNormal[];
 in vec3 tc_toLightVector[];
 in vec3 tc_toCameraVector[];
 in float tc_visibility[];
 in vec4 tc_shadowCoords[];
+in float tc_clipDistance[];
 
+/*===== out =====*/
 out vec2 te_textureCoords[];
 out vec3 te_surfaceNormal[];
 out vec3 te_toLightVector[];
 out vec3 te_toCameraVector[];
 out float te_visibility[];
 out vec4 te_shadowCoords[];
+out float te_clipDistance[];
 
+/*== constants =*/
 const int AB = 2;
 const int BC = 3;
 const int CD = 0;
 const int DA = 1;
 
+/*== uniforms ===*/
 uniform int tessellationFactor;
 uniform float tessellationSlope;
 uniform float tessellationShift;
 uniform vec3 cameraPosition;
 
+/*-------- functions -----------*/
 float LodFactor(float dist) {
 
 	float tessellationLevel = max(0.0, tessellationFactor/pow(dist, tessellationSlope) + tessellationShift);
@@ -34,6 +41,7 @@ float LodFactor(float dist) {
 	return tessellationLevel;
 }
 
+/*------------- main ---------------*/
 void main() {
 	if(gl_InvocationID == 0) {
 
@@ -57,12 +65,14 @@ void main() {
 
 	}
 
+	// simply pass parameters
 	te_surfaceNormal[gl_InvocationID] = tc_surfaceNormal[gl_InvocationID];
 	te_toLightVector[gl_InvocationID] = tc_toLightVector[gl_InvocationID];
 	te_toCameraVector[gl_InvocationID] = tc_toCameraVector[gl_InvocationID];
 	te_textureCoords[gl_InvocationID] = tc_textureCoords[gl_InvocationID];
 	te_visibility[gl_InvocationID] = tc_visibility[gl_InvocationID];
 	te_shadowCoords[gl_InvocationID] = tc_shadowCoords[gl_InvocationID];
+	te_clipDistance[gl_InvocationID] = tc_clipDistance[gl_InvocationID];
 
 	gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
 }

--- a/src/main/java/engine/shader/terrain/terrain_TC_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_TC_shader.glsl
@@ -5,7 +5,6 @@ layout (vertices = 16) out;
 
 /*===== in ======*/
 in vec2 tc_textureCoords[];
-in vec3 tc_surfaceNormal[];
 in vec3 tc_toLightVector[];
 in vec3 tc_toCameraVector[];
 in float tc_visibility[];
@@ -14,7 +13,6 @@ in float tc_clipDistance[];
 
 /*===== out =====*/
 out vec2 te_textureCoords[];
-out vec3 te_surfaceNormal[];
 out vec3 te_toLightVector[];
 out vec3 te_toCameraVector[];
 out float te_visibility[];
@@ -66,7 +64,6 @@ void main() {
 	}
 
 	// simply pass parameters
-	te_surfaceNormal[gl_InvocationID] = tc_surfaceNormal[gl_InvocationID];
 	te_toLightVector[gl_InvocationID] = tc_toLightVector[gl_InvocationID];
 	te_toCameraVector[gl_InvocationID] = tc_toCameraVector[gl_InvocationID];
 	te_textureCoords[gl_InvocationID] = tc_textureCoords[gl_InvocationID];

--- a/src/main/java/engine/shader/terrain/terrain_TE_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_TE_shader.glsl
@@ -5,25 +5,18 @@ layout (quads, equal_spacing, cw) in;
 
 /*===== in ======*/
 in vec2 te_textureCoords[];
-in vec3 te_toLightVector[];
-in vec3 te_toCameraVector[];
 in float te_visibility[];
 in vec4 te_shadowCoords[];
-in float te_clipDistance[];
 
 /*===== out =====*/
 out vec2 gs_textureCoords;
-out vec3 gs_toLightVector;
-out vec3 gs_toCameraVector;
 out float gs_visibility;
 out vec4 gs_shadowCoords;
-out float gs_clipDistance;
 
 /*== uniforms ===*/
 // matrix and planes
 uniform mat4 worldMatrix;
 uniform mat4 localMatrix;
-uniform mat4 transformationMatrix;
 uniform vec4 clipPlane;
 // maps
 uniform sampler2D heightMap;
@@ -69,11 +62,8 @@ void main() {
 	vec2 textureCoords = interpolate2D(te_textureCoords, u, v);
 	gs_textureCoords = textureCoords;
 
-	gs_toLightVector = interpolate3D(te_toLightVector, u, v);
-	gs_toCameraVector = interpolate3D(te_toCameraVector, u, v);
 	gs_visibility = interpolateFloat(te_visibility, u, v);
 	gs_shadowCoords = interpolate4D(te_shadowCoords, u, v);
-	gs_clipDistance = interpolateFloat(te_clipDistance, u, v);
 
 	// position - interpolate and add heights
 	vec4 position =

--- a/src/main/java/engine/shader/terrain/terrain_TE_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_TE_shader.glsl
@@ -3,28 +3,35 @@
 
 layout (quads, equal_spacing, cw) in;
 
+/*===== in ======*/
 in vec2 te_textureCoords[];
 in vec3 te_surfaceNormal[];
 in vec3 te_toLightVector[];
 in vec3 te_toCameraVector[];
 in float te_visibility[];
 in vec4 te_shadowCoords[];
+in float te_clipDistance[];
 
+/*===== out =====*/
 out vec2 gs_textureCoords;
 out vec3 gs_surfaceNormal;
 out vec3 gs_toLightVector;
 out vec3 gs_toCameraVector;
 out float gs_visibility;
 out vec4 gs_shadowCoords;
+out float gs_clipDistance;
 
+/*== uniforms ===*/
+// matrix and planes
 uniform mat4 worldMatrix;
 uniform mat4 localMatrix;
 uniform mat4 transformationMatrix;
 uniform vec4 clipPlane;
-
+// maps
 uniform sampler2D heightMap;
 uniform float scaleY;
 
+/*------ interpolate functions -------*/
 vec4 interpolate4D(vec4 vector[gl_MaxPatchVertices], float u, float v) {
 	return ((1-u) * (1-v) * vector[12] +
 			u * (1-v) * vector[0] +
@@ -53,20 +60,24 @@ float interpolateFloat(float vector[gl_MaxPatchVertices], float u, float v) {
 			(1-u) * v * vector[15]);
 }
 
+/*------------- main ---------------*/
 void main() {
 
+	// tess coordinates
 	float u = gl_TessCoord.x;
 	float v = gl_TessCoord.y;
 
+	// interpolate all variables between main points
 	vec2 textureCoords = interpolate2D(te_textureCoords, u, v);
 	gs_textureCoords = textureCoords;
 
-	gs_surfaceNormal = interpolate3D(te_surfaceNormal, u, v);
 	gs_toLightVector = interpolate3D(te_toLightVector, u, v);
 	gs_toCameraVector = interpolate3D(te_toCameraVector, u, v);
 	gs_visibility = interpolateFloat(te_visibility, u, v);
 	gs_shadowCoords = interpolate4D(te_shadowCoords, u, v);
+	gs_clipDistance = interpolateFloat(te_clipDistance, u, v);
 
+	// position - interpolate and add heights
 	vec4 position =
 		((1-u) * (1-v) * gl_in[12].gl_Position +
 		u * (1-v) * gl_in[0].gl_Position +
@@ -75,10 +86,7 @@ void main() {
 
 	float height = texture(heightMap, textureCoords).r;
 	height *= scaleY;
-	height -= 100;
 	position.y = height;
-
-	gl_ClipDistance[0] = dot(position, clipPlane);
 
 	gl_Position = position;
 

--- a/src/main/java/engine/shader/terrain/terrain_TE_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_TE_shader.glsl
@@ -3,28 +3,35 @@
 
 layout (quads, equal_spacing, cw) in;
 
+/*===== in ======*/
 in vec2 te_textureCoords[];
 in vec3 te_surfaceNormal[];
 in vec3 te_toLightVector[];
 in vec3 te_toCameraVector[];
 in float te_visibility[];
 in vec4 te_shadowCoords[];
+in float te_clipDistance[];
 
+/*===== out =====*/
 out vec2 gs_textureCoords;
 out vec3 gs_surfaceNormal;
 out vec3 gs_toLightVector;
 out vec3 gs_toCameraVector;
 out float gs_visibility;
 out vec4 gs_shadowCoords;
+out float gs_clipDistance;
 
+/*== uniforms ===*/
+// matrix and planes
 uniform mat4 worldMatrix;
 uniform mat4 localMatrix;
 uniform mat4 transformationMatrix;
 uniform vec4 clipPlane;
-
+// maps
 uniform sampler2D heightMap;
 uniform float scaleY;
 
+/*------ interpolate functions -------*/
 vec4 interpolate4D(vec4 vector[gl_MaxPatchVertices], float u, float v) {
 	return ((1-u) * (1-v) * vector[12] +
 			u * (1-v) * vector[0] +
@@ -53,6 +60,7 @@ float interpolateFloat(float vector[gl_MaxPatchVertices], float u, float v) {
 			(1-u) * v * vector[15]);
 }
 
+/*------------- main ---------------*/
 void main() {
 
 	float u = gl_TessCoord.x;
@@ -66,7 +74,9 @@ void main() {
 	gs_toCameraVector = interpolate3D(te_toCameraVector, u, v);
 	gs_visibility = interpolateFloat(te_visibility, u, v);
 	gs_shadowCoords = interpolate4D(te_shadowCoords, u, v);
+	gs_clipDistance = interpolateFloat(te_clipDistance, u, v);
 
+	// position - interpolate and add heights
 	vec4 position =
 		((1-u) * (1-v) * gl_in[12].gl_Position +
 		u * (1-v) * gl_in[0].gl_Position +
@@ -75,10 +85,7 @@ void main() {
 
 	float height = texture(heightMap, textureCoords).r;
 	height *= scaleY;
-	height -= 100;
 	position.y = height;
-
-	gl_ClipDistance[0] = dot(position, clipPlane);
 
 	gl_Position = position;
 

--- a/src/main/java/engine/shader/terrain/terrain_TE_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_TE_shader.glsl
@@ -5,7 +5,6 @@ layout (quads, equal_spacing, cw) in;
 
 /*===== in ======*/
 in vec2 te_textureCoords[];
-in vec3 te_surfaceNormal[];
 in vec3 te_toLightVector[];
 in vec3 te_toCameraVector[];
 in float te_visibility[];
@@ -14,7 +13,6 @@ in float te_clipDistance[];
 
 /*===== out =====*/
 out vec2 gs_textureCoords;
-out vec3 gs_surfaceNormal;
 out vec3 gs_toLightVector;
 out vec3 gs_toCameraVector;
 out float gs_visibility;

--- a/src/main/java/engine/shader/terrain/terrain_V_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_V_shader.glsl
@@ -18,12 +18,10 @@ out float tc_clipDistance;
 
 /*== uniforms ==*/
 uniform int lightCount;
-uniform mat4 projectionMatrix;
 uniform mat4 viewMatrix;
 uniform vec3 lightPosition[LIGHT_MAX];
 
 uniform sampler2D heightMap;
-uniform sampler2D normalMap;
 
 uniform mat4 toShadowMapSpace;
 uniform float shadowDistance;

--- a/src/main/java/engine/shader/terrain/terrain_V_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_V_shader.glsl
@@ -6,20 +6,18 @@
 
 /*===== in ======*/
 in vec3 in_position;
-in vec2 textureCoordinates;
 
 /*===== out =====*/
-out vec3 tc_toLightVector[LIGHT_MAX];
-out vec3 tc_toCameraVector;
 out float tc_visibility;
 out vec4 tc_shadowCoords;
 out vec2 tc_textureCoords;
 out float tc_clipDistance;
 
 /*== uniforms ==*/
-uniform int lightCount;
 uniform mat4 viewMatrix;
-uniform vec3 lightPosition[LIGHT_MAX];
+uniform mat4 projectionMatrix;
+uniform mat4 localMatrix;
+uniform mat4 worldMatrix;
 
 uniform sampler2D heightMap;
 
@@ -29,14 +27,10 @@ uniform float shadowTransitionDistance;
 
 uniform float fogDensity;
 
-uniform vec4 clipPlane;
-
 uniform vec3 cameraPosition;
 uniform float scaleY;
 uniform int lod;
 uniform vec2 index;
-uniform mat4 localMatrix;
-uniform mat4 worldMatrix;
 uniform float gap;
 uniform vec2 location;
 
@@ -168,23 +162,15 @@ void main(void) {
    float height = texture(heightMap, localPosition.xz).r;
    localPosition.y = height;
 
-   vec4 worldPosition = worldMatrix * vec4(localPosition, 1.0);
+   vec4 worldPosition =  (worldMatrix * vec4(localPosition, 1.0));
    
    tc_shadowCoords = toShadowMapSpace * vec4(worldPosition.x, 0.0, worldPosition.z, 1.0);
-
-   tc_clipDistance = dot(worldPosition, clipPlane);
    
    vec4 positionRelativeToCam = viewMatrix * worldPosition;
 
    gl_Position = worldPosition;
 
    tc_textureCoords = localPosition.xz;
-
-   for(int i = 0; i < LIGHT_MAX; i++) {
-      tc_toLightVector[i] = lightPosition[i] - localPosition;
-   }
-
-   tc_toCameraVector = (inverse(viewMatrix) * vec4(0.0,0.0,0.0,1.0)).xyz - localPosition;
    
    float distance = length(positionRelativeToCam.xyz);
    tc_visibility = exp(-pow((distance * fogDensity), fogGradient));

--- a/src/main/java/engine/shader/terrain/terrain_V_shader.glsl
+++ b/src/main/java/engine/shader/terrain/terrain_V_shader.glsl
@@ -1,8 +1,8 @@
 //VERTEX SHADER - Terrain
 #version 430 core
 
-#define LOD_MAX 8 //max level of distance count
-#define LIGHT_MAX 10 //max light source count
+#define LOD_MAX 8 // max level of distance count
+#define LIGHT_MAX 10 // max light source count
 
 /*===== in ======*/
 in vec3 in_position;
@@ -16,6 +16,7 @@ out vec3 tc_toCameraVector;
 out float tc_visibility;
 out vec4 tc_shadowCoords;
 out vec2 tc_textureCoords;
+out float tc_clipDistance;
 
 /*== uniforms ==*/
 uniform int lightCount;
@@ -162,7 +163,7 @@ vec2 morph(vec2 localPosition, int morph_area) {
 /*------------- main ---------------*/
 void main(void) {
 
-   vec3 localPosition = (localMatrix * vec4(in_position.x, in_position.y, in_position.z, 1.0)).xyz;
+   vec3 localPosition = (localMatrix * vec4(in_position, 1.0)).xyz;
 
    if(lod > 0.0) {
 	  localPosition.xz += morph(localPosition.xz, lod_morph_area[lod-1]);
@@ -175,7 +176,7 @@ void main(void) {
    
    tc_shadowCoords = toShadowMapSpace * vec4(worldPosition.x, 0.0, worldPosition.z, 1.0);
 
-   gl_ClipDistance[0] = dot(worldPosition, clipPlane);
+   tc_clipDistance = dot(worldPosition, clipPlane);
    
    vec4 positionRelativeToCam = viewMatrix * worldPosition;
 
@@ -193,7 +194,7 @@ void main(void) {
    
    float distance = length(positionRelativeToCam.xyz);
    tc_visibility = exp(-pow((distance * fogDensity), fogGradient));
-   tc_visibility = clamp(tc_visibility,0.0,1.0);
+   tc_visibility = clamp(tc_visibility, 0.0, 1.0);
    
    distance = distance - (shadowDistance - shadowTransitionDistance);
    distance = distance / shadowTransitionDistance;

--- a/src/main/java/engine/shader/water/water_F_shader.glsl
+++ b/src/main/java/engine/shader/water/water_F_shader.glsl
@@ -77,6 +77,7 @@ void main(void) {
 	
 	out_Color = mix(reflectColour, refractColour, refractiveFactor);
 	out_Color = mix(out_Color, vec4(0.0, 0.3, 0.5, 1.0), 0.2) + vec4(specularHighlights, 0.0);
+	out_Color = mix(out_Color, vec4(skyColor, 1.0), visibility);
     out_Color.a = clamp(waterDepth/5.0, 0.0, 1.0);
     out_BrightColor = vec4(0.0);
     

--- a/src/main/java/engine/shader/water/water_V_shader.glsl
+++ b/src/main/java/engine/shader/water/water_V_shader.glsl
@@ -36,7 +36,7 @@ void main(void) {
 	toCameraVector = cameraPosition - worldPosition.xyz;
 	fromLightVector = worldPosition.xyz - lightPosition;
 	
-	float distance = length(positionRelativeToCam.xyz);
+	float distance = length(positionRelativeToCam.xyz * tiling);
    	visibility = exp(-pow((distance*fogDensity),fogGradient));
    	visibility = clamp(visibility,0.0,1.0);
  


### PR DESCRIPTION
Add system for rendering height map from position buffer array object.
- use texture buffer object as storage for buffer array;
- store height position from texture buffer into the height map by compute shader;
- use graphic user interface (GUI) to show normal and height textures for debugging (press F1);
---
At the screenshot:
left - height map generated from buffer object (through buffer texture object), 
right -  normal map generated from height map.

![default](https://user-images.githubusercontent.com/21068350/32462054-b84ac3ba-c340-11e7-8744-233603bbf6f6.png)
----
in future:
1) planning to refactor terrain class and unite different type of terrain, also use terrain material object for storing textures;
2) At computing height map planning to use scalable value to change smoothness of theight map due to different input heights values size;

P.S. Also link https://trello.com/b/OO1zK4lW/gameengine to see engine work plans for present time.